### PR TITLE
Refresh against current Mono docs (drift-only, v1.1.0)

### DIFF
--- a/Mono.Core.Tests/Mono.Core.Tests.csproj
+++ b/Mono.Core.Tests/Mono.Core.Tests.csproj
@@ -11,6 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
+    <PackageReference Include="Moq" Version="4.20.70" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Mono.Core/Mono.Core.csproj
+++ b/Mono.Core/Mono.Core.csproj
@@ -1,11 +1,11 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<TargetFramework>netstandard2.0</TargetFramework>
 		<PackageId>
 			Mono.Core
 		</PackageId>
 		<Version>
-			1.0.11
+			1.1.0
 		</Version>
 		<Authors>
 			Adelowomi
@@ -19,9 +19,7 @@
 		<PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.5" />
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
 		<PackageReference Include="Microsoft.Extensions.Options" Version="8.0.2" />
-		<PackageReference Include="Moq" Version="4.20.70" />
-		<PackageReference Include="Newtonsoft.Json.Bson" Version="1.0.3-beta1" />
-		<PackageReference Include="Refit" Version="7.1.2" />
+		<PackageReference Include="Refit" Version="7.2.22" />
 		<None Include="../Readme.md" PackagePath="\" />
 	</ItemGroup>
 </Project>

--- a/Mono.Core/Services/DirectPay/Abstractions/IDirectPayService.cs
+++ b/Mono.Core/Services/DirectPay/Abstractions/IDirectPayService.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -34,9 +34,10 @@ namespace Mono.Core.DirectPay
         [Post("/payments/mandates/{id}/debit")]
         Task<IApiResponse<MonoStandardResponse<DebitAccountResponse>>> DebitMandate(DebitAccountModel debitMandateModel,string id, CancellationToken cancellationToken = default);
 
-        // /payments/mandates/id/balance-inquiry?amount=1000
+        // /payments/mandates/id/balance-inquiry?amount=1000 — amount optional;
+        // present = sufficient-funds check (NGN 10), absent = current balance (NGN 50)
         [Get("/payments/mandates/{id}/balance-inquiry")]
-        Task<IApiResponse<MonoStandardResponse<BalanceEnquiryResponse>>> BalanceInquiry(string id, [Query] string amount, CancellationToken cancellationToken = default);
+        Task<IApiResponse<MonoStandardResponse<BalanceEnquiryResponse>>> BalanceInquiry(string id, [Query] string amount = null, CancellationToken cancellationToken = default);
 
         // /payments/mandates/id/reinstate
         [Patch("/payments/mandates/{id}/reinstate")]

--- a/Mono.Core/Services/DirectPay/Abstractions/IMonoDirectPay.cs
+++ b/Mono.Core/Services/DirectPay/Abstractions/IMonoDirectPay.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -62,10 +62,10 @@ namespace Mono.Core.DirectPay
         /// This method checks the balance of a mandate based on the provided mandate id and amount.
         /// </summary>
         /// <param name="id">The mandate id used to check the balance.</param>
-        /// <param name="amount">The amount used to check the balance of the mandate.</param>
+        /// <param name="amount">Optional. When provided, performs a sufficient-funds check (NGN 10). When null, returns the current balance (NGN 50).</param>
         /// <param name="cancellationToken">A Cancellation token that can be used to cancel the task. This will terminate the HTTP request if triggered.</param>
         /// <returns>A synchronous task that returns a MonoStandardResponse and a BalanceEnquiryResponse.</returns>
-        Task<MonoStandardResponse<BalanceEnquiryResponse>> BalanceInquiry(string id, string amount, CancellationToken cancellationToken = default);
+        Task<MonoStandardResponse<BalanceEnquiryResponse>> BalanceInquiry(string id, string amount = null, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// This method reinstates a mandate based on the provided mandate id.

--- a/Mono.Core/Services/DirectPay/DirectPayService.cs
+++ b/Mono.Core/Services/DirectPay/DirectPayService.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -54,7 +54,7 @@ namespace Mono.Core.DirectPay
             return response.HandleResponse();
         }
 
-        public async Task<MonoStandardResponse<BalanceEnquiryResponse>> BalanceInquiry(string id, string amount, CancellationToken cancellationToken = default)
+        public async Task<MonoStandardResponse<BalanceEnquiryResponse>> BalanceInquiry(string id, string amount = null, CancellationToken cancellationToken = default)
         {
             var response = await _directPayServiceV3.BalanceInquiry(id, amount, cancellationToken);
             return response.HandleResponse();

--- a/Mono.Core/Services/DirectPay/Models/CreateMandateModel.cs
+++ b/Mono.Core/Services/DirectPay/Models/CreateMandateModel.cs
@@ -26,14 +26,47 @@ namespace Mono.Core.Services.DirectPay.Models
         [JsonPropertyName("bank_code")]
         public string BankCode { get; set; }
 
+        [JsonPropertyName("fee_bearer")]
+        public string FeeBearer { get; set; }
+
         [JsonPropertyName("description")]
         public string Description { get; set; }
+
+        [JsonPropertyName("verification_method")]
+        public string VerificationMethod { get; set; }
 
         [JsonPropertyName("start_date")]
         public string StartDate { get; set; }
 
         [JsonPropertyName("end_date")]
         public string EndDate { get; set; }
+
+        [JsonPropertyName("meta")]
+        public object Meta { get; set; }
+    }
+
+    public class FeeBearerConstants
+    {
+        public const string Business = "business";
+        public const string Customer = "customer";
+    }
+
+    public class MandateTypeConstants
+    {
+        public const string EMandate = "emandate";
+        public const string Sweep = "sweep";
+    }
+
+    public class DebitTypeConstants
+    {
+        public const string Variable = "variable";
+        public const string Fixed = "fixed";
+    }
+
+    public class VerificationMethodConstants
+    {
+        public const string TransferVerification = "transfer_verification";
+        public const string SelfieVerification = "selfie_verification";
     }
 }
 

--- a/Mono.Core/Services/LookUp/Abstractions/ILookUpService.cs
+++ b/Mono.Core/Services/LookUp/Abstractions/ILookUpService.cs
@@ -1,5 +1,6 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
@@ -14,12 +15,12 @@ namespace Mono.Core.LookUp
         [Post("/lookup/bvn/initiate")]
         Task<IApiResponse<MonoStandardResponse<InitiateBvnLookUpResponseModel>>> InitiateBvnLookUp([Body] InitiateBvnLookUpModel bvnInitiateRequestModel, CancellationToken cancellationToken = default);
 
-        // /lookup/bvn/verify
-        [Post("/lookup/bvn/verify")]
+        // /lookup/bvn/verify-otp (renamed from /verify per Mono BVN iGree docs)
+        [Post("/lookup/bvn/verify-otp")]
         Task<IApiResponse<MonoStandardResponse<dynamic>>> VerifyBvnLookUp([Body] VerifyBvnLookUpOtpModel bvnVerifyRequestModel, [Header("x-session-id")] string sessionId, CancellationToken cancellationToken = default);
 
-        // /lookup/bvn/details
-        [Post("/lookup/bvn/details")]
+        // /lookup/bvn/fetch-bvn (renamed from /details per Mono BVN iGree docs)
+        [Post("/lookup/bvn/fetch-bvn")]
         Task<IApiResponse<MonoStandardResponse<BvnDetailsResponse>>> GetBvnDetails([Body] BvnDetailsModel bvnDetailsModel,[Header("x-session-id")] string sessionId, CancellationToken cancellationToken = default);
         #endregion
 
@@ -33,10 +34,12 @@ namespace Mono.Core.LookUp
         Task<IApiResponse<MonoStandardResponse<List<OfficialDetails>>>> GetCacCompany(string businessId, CancellationToken cancellationToken = default);
 
         // /lookup/cac/company/266914/previous-address // previous address
+        [Obsolete("Deprecated by Mono. Use the CAC Profile endpoint when it is implemented in a future release.")]
         [Get("/lookup/cac/company/{businessId}/previous-address")]
         Task<IApiResponse<MonoStandardResponse<PreviousAddressResponse>>> GetPreviousAddress(string businessId, CancellationToken cancellationToken = default);
 
         // /lookup/cac/company/322175/change-of-name
+        [Obsolete("Deprecated by Mono. Use the CAC Profile endpoint when it is implemented in a future release.")]
         [Get("/lookup/cac/company/{businessId}/change-of-name")]
         Task<IApiResponse<MonoStandardResponse<ChangeOfNameResponse>>> GetChangeOfName(string businessId, CancellationToken cancellationToken = default);
 
@@ -56,35 +59,35 @@ namespace Mono.Core.LookUp
         Task<IApiResponse<MonoStandardResponse<BanksResponse>>> GetBanks(CancellationToken cancellationToken = default);
 
         // /lookup/address
-        [Get("/lookup/address")]
+        [Post("/lookup/address")]
         Task<IApiResponse<MonoStandardResponse<AddressLookUpResponseModel>>> GetAddress([Body] AddressLookUpRequestModel addressLookUpRequestModel, CancellationToken cancellationToken = default);
 
-        // /lookup/passport
-        [Get("/lookup/passport")]
+        // /lookup/intl-passport
+        [Post("/lookup/intl-passport")]
         Task<IApiResponse<MonoStandardResponse<InternationalPassportResponse>>> GetPassport([Body] InternationalPassportRequestModel passportLookUpRequestModel, CancellationToken cancellationToken = default);
 
         // /lookup/tin
-        [Get("/lookup/tin")]
+        [Post("/lookup/tin")]
         Task<IApiResponse<MonoStandardResponse<TinResponseModel>>> GetTin([Body] TinRequestModel tinLookUpRequestModel, CancellationToken cancellationToken = default);
 
         // /lookup/nin
-        [Get("/lookup/nin")]
+        [Post("/lookup/nin")]
         Task<IApiResponse<MonoStandardResponse<NinResponseModel>>> GetNin([Body] NinRequestModel ninLookUpRequestModel, CancellationToken cancellationToken = default);
 
-        // lookup/driver_license
-        [Get("/lookup/driver_license")]
+        // /lookup/drivers-license (renamed from driver_license per current Mono lookup docs)
+        [Post("/lookup/drivers-license")]
         Task<IApiResponse<MonoStandardResponse<DriversLicenseResponse>>> GetDriverLicense([Body] DriversLicenseRequestModel driverLicenseLookUpRequestModel, CancellationToken cancellationToken = default);
 
         // /lookup/account-number
-        [Get("/lookup/account-number")]
+        [Post("/lookup/account-number")]
         Task<IApiResponse<MonoStandardResponse<AccountResponse>>> GetAccountNumber([Body] AccountRequestModel accountNumberLookUpRequestModel, CancellationToken cancellationToken = default);
 
-        // /lookup/credit-history/{provider}
-        [Get("/lookup/credit-history/{provider}")]
+        // /lookup/credit-history/{provider} — provider in path: crc | xds | all
+        [Post("/lookup/credit-history/{provider}")]
         Task<IApiResponse<MonoStandardResponse<CreditHistoryResponse>>> GetCreditHistory(string provider, [Body] CreditHistoryRequestModel creditHistoryLookUpRequestModel, CancellationToken cancellationToken = default);
 
         // /lookup/mashup
-        [Get("/lookup/mashup")]
+        [Post("/lookup/mashup")]
         Task<IApiResponse<MonoStandardResponse<MashUpResponse>>> GetMashUp([Body] MashUpRequestModel mashUpLookUpRequestModel, CancellationToken cancellationToken = default);
 
         #endregion

--- a/Mono.Core/Services/LookUp/Abstractions/IMonoLookUpService.cs
+++ b/Mono.Core/Services/LookUp/Abstractions/IMonoLookUpService.cs
@@ -1,5 +1,6 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -54,6 +55,7 @@ namespace Mono.Core.LookUp
         /// <param name="businessId">The ID to retrive the address for a specific business</param>
         /// <param name="cancellationToken">A Cancellation token that can be used to cancel the task. i.e This will terminate the http request</param>
         /// <returns>An asynchronous operations that returns a MonoStandardResponse containing PreviousAddressResponse.</returns>
+        [Obsolete("Deprecated by Mono. The Previous Address CAC endpoint has been retired; use the CAC Profile endpoint when it ships.")]
         Task<MonoStandardResponse<PreviousAddressResponse>> GetPreviousAddress(string businessId, CancellationToken cancellationToken = default);
 
          /// <summary>
@@ -62,6 +64,7 @@ namespace Mono.Core.LookUp
         /// <param name="businessId">The Id to change the name of a specific business.</param>
         /// <param name="cancellationToken">A Cancellation token that can be used to cancel the task. i.e This will terminate the http request</param>
         /// <returns>An asynchronous operations that returns a MonoStandardResponse containing ChangeOfNameResponse.</returns>
+        [Obsolete("Deprecated by Mono. The Change of Name CAC endpoint has been retired; use the CAC Profile endpoint when it ships.")]
         Task<MonoStandardResponse<ChangeOfNameResponse>> GetChangeOfName(string businessId, CancellationToken cancellationToken = default);
 
          /// <summary>

--- a/Mono.Core/Services/LookUp/LookUpService.cs
+++ b/Mono.Core/Services/LookUp/LookUpService.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -49,15 +49,21 @@ namespace Mono.Core.LookUp
             return response.HandleResponse();
         }
 
+        [Obsolete("Deprecated by Mono. Use the CAC Profile endpoint when it ships.")]
         public async Task<MonoStandardResponse<PreviousAddressResponse>> GetPreviousAddress(string businessId, CancellationToken cancellationToken = default)
         {
+#pragma warning disable CS0618
             var response = await _lookUpServiceV3.GetPreviousAddress(businessId, cancellationToken);
+#pragma warning restore CS0618
             return response.HandleResponse();
         }
 
+        [Obsolete("Deprecated by Mono. Use the CAC Profile endpoint when it ships.")]
         public async Task<MonoStandardResponse<ChangeOfNameResponse>> GetChangeOfName(string businessId, CancellationToken cancellationToken = default)
         {
+#pragma warning disable CS0618
             var response = await _lookUpServiceV3.GetChangeOfName(businessId, cancellationToken);
+#pragma warning restore CS0618
             return response.HandleResponse();
         }
 

--- a/Mono.Core/Services/LookUp/Models/BvnLookUpModels.cs
+++ b/Mono.Core/Services/LookUp/Models/BvnLookUpModels.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Text.Json.Serialization;
@@ -16,8 +16,8 @@ namespace Mono.Core.LookUp
 
     public class ScopeConstants
     {
-        public const string Identity = "IDENTITY";
-        public const string BankAccounts = "BANK_ACCOUNTS";
+        public const string Identity = "identity";
+        public const string BankAccounts = "bank_accounts";
     }
 
     public class Methods

--- a/Readme.md
+++ b/Readme.md
@@ -179,8 +179,8 @@ This interface provides methods for looking up information in Mono.
 - `GetBvnDetails` This method is use to retrieve BVN Information requested.
 - `GetCacLookUp` This method is used to get specific business information is a company.
 - `GetCacCompany` This method is use to get official information of an existence business.
-- `GetPreviousAddress` This method is use to check previous company address.
-- `GetChangeOfName` This method is use to check the history of a business name change.
+- `GetPreviousAddress` *(Deprecated by Mono — retained for source compatibility)*
+- `GetChangeOfName` *(Deprecated by Mono — retained for source compatibility)*
 - `GetSecretary` This method is used to search for the company secretary.
 - `GetDirectors` This method is used to search for the company directors.
 - `GetBanks` This method returns NIP supported bank coverage.
@@ -200,6 +200,31 @@ This interface provides miscellaneous methods for managing Mono.
 - `GetCacLookup` This method to retieve cac lookup information.
 - `GetCacCompany` This method is use to retrieve shareholder information of a company.
 - `UnLinkAccount` This method provide you with the option to unlink their financial account(s).
+
+## Changes in 1.1.0 (May 2026)
+
+Drift-only refresh against the current Mono docs. Future product surfaces (Customers, Disburse, Watchlist, Prove, transaction enrichment) will land in follow-up releases.
+
+**Endpoints fixed:**
+- BVN: `/lookup/bvn/verify` → `/lookup/bvn/verify-otp`
+- BVN: `/lookup/bvn/details` → `/lookup/bvn/fetch-bvn`
+- BVN `scope` values now lowercase (`identity`, `bank_accounts`) to match the API
+- Lookups for address, passport, TIN, NIN, drivers-license, account-number, credit-history, mashup are now `POST` (they were declared `[Get]` with `[Body]` — invalid in Refit and inconsistent with the docs)
+- Driver's license path: `/lookup/driver_license` → `/lookup/drivers-license`
+- International passport path: `/lookup/passport` → `/lookup/intl-passport`
+- Mandate balance enquiry: `amount` query parameter is now optional. Present = sufficient-funds check (NGN 10), absent = real-time balance (NGN 50)
+
+**Deprecated (kept for source compatibility, marked `[Obsolete]`):**
+- `IMonoLookUp.GetPreviousAddress` — Mono retired the CAC previous-address endpoint
+- `IMonoLookUp.GetChangeOfName` — Mono retired the CAC change-of-name endpoint
+
+**Mandate creation:**
+- `CreateMandateModel` adds `fee_bearer`, `verification_method`, and `meta` fields per the v3 docs
+- New string constants: `MandateTypeConstants` (emandate/sweep), `DebitTypeConstants` (variable/fixed), `FeeBearerConstants` (business/customer), `VerificationMethodConstants` (transfer_verification/selfie_verification)
+
+**Security / dependencies:**
+- Refit bumped to `7.2.22` to address [CVE-2024-51501](https://github.com/advisories/GHSA-3hxg-fxwm-8gf7) (CRLF header injection)
+- Removed unused `Moq` and `Newtonsoft.Json.Bson` from the runtime package; `Moq` moved to the test project where it belongs
 
 ## Contributing
 


### PR DESCRIPTION
## Summary

Drift-only refresh of `Mono.Core` against the live Mono API docs (as of May 2026). The library hadn't been touched since September 2024 and several endpoints had silently broken or moved.

This PR fixes the endpoints that have moved, switches the misdeclared `[Get]+[Body]` lookups to `POST`, deprecates the two CAC endpoints Mono retired, and patches a critical Refit CVE. **No new product surfaces** — Customers, Disburse, Watchlist, Prove, and the transaction-enrichment APIs are deliberately deferred to follow-up PRs.

## Endpoint drift fixes

| Surface | Before | After |
| --- | --- | --- |
| BVN verify | `POST /lookup/bvn/verify` | `POST /lookup/bvn/verify-otp` |
| BVN details | `POST /lookup/bvn/details` | `POST /lookup/bvn/fetch-bvn` |
| BVN scope values | `IDENTITY` / `BANK_ACCOUNTS` | `identity` / `bank_accounts` |
| Lookup verbs | `[Get]` + `[Body]` (invalid in Refit) | `[Post]` |
| Driver's license path | `/lookup/driver_license` | `/lookup/drivers-license` |
| Int'l passport path | `/lookup/passport` | `/lookup/intl-passport` |
| Balance enquiry `amount` | required query | optional (present = sufficient-funds check NGN 10, absent = real-time balance NGN 50) |

The `[Get]` + `[Body]` lookups (address, passport, TIN, NIN, drivers-license, account-number, credit-history, mashup) didn't actually work — Refit silently drops the body on GET, so anyone calling them would have been making bodyless requests against endpoints that now expect POST anyway.

## Deprecations

CAC endpoints Mono retired (kept on the interface with `[Obsolete]` for source-compat):
- `IMonoLookUp.GetPreviousAddress`
- `IMonoLookUp.GetChangeOfName`

Per Mono's docs, the **CAC Profile endpoint** is the intended replacement. A follow-up PR will add it once we tackle the CAC expansion (PSC, Profile, Status Report) holistically.

## Mandate creation — new optional fields

`CreateMandateModel` picks up the v3 fields:
- `fee_bearer` (business / customer)
- `verification_method` (transfer_verification / selfie_verification)
- `meta`

Plus string constants for safety: `MandateTypeConstants`, `DebitTypeConstants`, `FeeBearerConstants`, `VerificationMethodConstants`.

## Security & packaging

- **Refit 7.1.2 → 7.2.22** — fixes [CVE-2024-51501](https://github.com/advisories/GHSA-3hxg-fxwm-8gf7), a CRLF header-injection bug that affects every `[Header(...)]` use in this library (notably the BVN session-id headers)
- Dropped `Moq` and `Newtonsoft.Json.Bson` from the runtime package — both were unused in `Mono.Core` itself
- `Moq` moved to `Mono.Core.Tests` where it actually belongs
- Package version: **1.0.11 → 1.1.0**

## Out of scope (follow-up PRs)

- **Customers API** (CRUD, transactions, linked accounts, business customers) — added by Mono March 2024
- **Disburse API** (source accounts, instant + scheduled disbursements, batch distributions) — added September 2025
- **Watchlist Screening** — March 2026
- **Prove** identity verification
- **Connect additions**: Get-All-Accounts, real-time `account-balance`, Account Match
- **NIN poll-job** endpoint + `output=pdf` flag
- **CAC**: PSC, Profile, Status Report (replaces the deprecated previous-address / change-of-name)
- **DirectPay**: Refund, Payout (by status), Payout Transactions
- **Webhook hardening**: `mono-webhook-secret` signature verification, new event types (`debit.successful`, income, creditworthiness, disburse), new event fields (`event_id`, `timestamp`, `app`, `business`, `retrieved_data`, `has_new_data`)
- **Webhook controller**: race condition on `_eventType` mutable field under concurrent requests

## Test plan

- [x] `dotnet build` — succeeds with warnings only
- [x] `dotnet test` — pre-existing test infrastructure issue (50/59 fail on master too, all `NullReferenceException` from mock setup that doesn't return inner services); this PR neither introduces nor fixes those. Worth a dedicated cleanup PR.
- [ ] Smoke-test against Mono sandbox using a sample app before publishing to NuGet
- [ ] Confirm consumers calling `BalanceInquiry(id, amount)` with positional args still compile (signature changed `string amount` → `string amount = null` — source-compatible)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Refresh Mono.Core lookup and DirectPay surfaces to align with current Mono API behavior, while preserving source compatibility and documenting the 1.1.0 changes.

New Features:
- Extend mandate creation to support fee bearer, verification method, and meta fields along with constants for mandate, debit, fee bearer, and verification-method types.

Bug Fixes:
- Update BVN lookup endpoints, paths, and scope values to match the live Mono BVN API.
- Correct lookup operations (address, passport, TIN, NIN, drivers-license, account-number, credit-history, mashup) to use POST with bodies instead of invalid GET-with-body declarations.
- Make the DirectPay mandate balance-inquiry amount parameter optional to reflect Mono's semantics for sufficient-funds versus balance checks.

Enhancements:
- Mark retired CAC previous-address and change-of-name endpoints as obsolete across interfaces and implementations, while keeping them callable for existing consumers.
- Align driver's-license and international-passport lookup routes with the latest Mono documentation.

Documentation:
- Add a 1.1.0 changelog section to the README summarizing endpoint fixes, deprecations, mandate enhancements, and dependency updates, and note CAC lookup deprecations in the IMonoLookUp method list.