### PR TITLE
Add Mono Customer API surface (v1.2.0)

### DIFF
--- a/Mono.Core/Extensions/IServiceCollectionExtension.cs
+++ b/Mono.Core/Extensions/IServiceCollectionExtension.cs
@@ -1,8 +1,9 @@
-﻿using System;
+using System;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Mono.Core.Accounts;
 using Mono.Core.Authorization;
+using Mono.Core.Customers;
 using Mono.Core.DirectPay;
 using Mono.Core.LookUp;
 using Mono.Core.Miscellaneous; // Add this using directive
@@ -20,6 +21,7 @@ namespace Mono.Core
             services.AddTransient<IMonoDirectPay, DirectPayService>();
             services.AddTransient<IMonoMiscellaneous, MiscellaneousService>(); // Add this line
             services.AddTransient<IMonoLookUp, LookUpService>();
+            services.AddTransient<IMonoCustomers, CustomerService>();
             return services;
         }
 
@@ -63,6 +65,14 @@ namespace Mono.Core
             return services;
         }
 
-        
+        public static IServiceCollection AddMonoCustomers(this IServiceCollection services, Action<MonoInitializationOptions> options)
+        {
+            services.Configure(options);
+            services.AddTransient(typeof(IRefitClientBuilder<>), typeof(RefitClientBuilder<>));
+            services.AddTransient<IMonoCustomers, CustomerService>();
+            return services;
+        }
+
+
     }
 }

--- a/Mono.Core/Mono.Core.csproj
+++ b/Mono.Core/Mono.Core.csproj
@@ -5,7 +5,7 @@
 			Mono.Core
 		</PackageId>
 		<Version>
-			1.1.0
+			1.2.0
 		</Version>
 		<Authors>
 			Adelowomi

--- a/Mono.Core/Services/Customers/Abstractions/ICustomerService.cs
+++ b/Mono.Core/Services/Customers/Abstractions/ICustomerService.cs
@@ -1,0 +1,62 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Refit;
+
+namespace Mono.Core.Customers
+{
+    // Refit interface for the Mono Customer API (v2). The high-level
+    // IMonoCustomers facade wraps these calls and unwraps the response.
+    public interface ICustomerService
+    {
+        // POST /customers — individual variant
+        [Post("/customers")]
+        Task<IApiResponse<MonoStandardResponse<CustomerResponse>>> CreateIndividualCustomer(
+            [Body] CreateIndividualCustomerModel model,
+            CancellationToken cancellationToken = default);
+
+        // POST /customers — business variant
+        [Post("/customers")]
+        Task<IApiResponse<MonoStandardResponse<CustomerResponse>>> CreateBusinessCustomer(
+            [Body] CreateBusinessCustomerModel model,
+            CancellationToken cancellationToken = default);
+
+        // GET /customers/{id}
+        [Get("/customers/{id}")]
+        Task<IApiResponse<MonoStandardResponse<CustomerResponse>>> RetrieveCustomer(
+            string id,
+            CancellationToken cancellationToken = default);
+
+        // GET /customers
+        [Get("/customers")]
+        Task<IApiResponse<MonoStandardResponse<CustomerListResponse>>> ListCustomers(
+            [Query] CustomerListQueryOptions options,
+            CancellationToken cancellationToken = default);
+
+        // GET /customers/{id}/transactions
+        [Get("/customers/{id}/transactions")]
+        Task<IApiResponse<MonoStandardResponse<CustomerTransactionsResponse>>> GetCustomerTransactions(
+            string id,
+            [Query] CustomerTransactionsQueryOptions options,
+            CancellationToken cancellationToken = default);
+
+        // GET /accounts — Mono files "fetch all linked accounts" under the
+        // Customer product even though the path is global.
+        [Get("/accounts")]
+        Task<IApiResponse<MonoStandardResponse<LinkedAccountsResponse>>> FetchAllLinkedAccounts(
+            [Query] LinkedAccountsQueryOptions options,
+            CancellationToken cancellationToken = default);
+
+        // PATCH /customers/{id}
+        [Patch("/customers/{id}")]
+        Task<IApiResponse<MonoStandardResponse<CustomerResponse>>> UpdateCustomer(
+            string id,
+            [Body] UpdateCustomerModel model,
+            CancellationToken cancellationToken = default);
+
+        // DELETE /customers/{id}
+        [Delete("/customers/{id}")]
+        Task<IApiResponse<MonoStandardResponse<dynamic>>> DeleteCustomer(
+            string id,
+            CancellationToken cancellationToken = default);
+    }
+}

--- a/Mono.Core/Services/Customers/Abstractions/IMonoCustomers.cs
+++ b/Mono.Core/Services/Customers/Abstractions/IMonoCustomers.cs
@@ -1,0 +1,72 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Mono.Core.Customers
+{
+    public interface IMonoCustomers
+    {
+        /// <summary>
+        /// Creates a unique individual customer. Returns 400 if a customer with the
+        /// same identity already exists.
+        /// </summary>
+        Task<MonoStandardResponse<CustomerResponse>> CreateIndividualCustomer(
+            CreateIndividualCustomerModel model,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Creates a unique business customer. <c>identity</c>, <c>email</c>,
+        /// <c>business_name</c>, <c>address</c>, and <c>phone</c> are all required.
+        /// </summary>
+        Task<MonoStandardResponse<CustomerResponse>> CreateBusinessCustomer(
+            CreateBusinessCustomerModel model,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Retrieves a single customer by id.
+        /// </summary>
+        Task<MonoStandardResponse<CustomerResponse>> RetrieveCustomer(
+            string id,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Lists customers with optional pagination and filters.
+        /// </summary>
+        Task<MonoStandardResponse<CustomerListResponse>> ListCustomers(
+            CustomerListQueryOptions options = null,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Retrieves transactions performed by a customer across Mono's payment products.
+        /// Supports filtering by period (e.g. "last12months"), page and linked account.
+        /// </summary>
+        Task<MonoStandardResponse<CustomerTransactionsResponse>> GetCustomerTransactions(
+            string id,
+            CustomerTransactionsQueryOptions options = null,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Retrieves every account linked to the business. Mono documents this under
+        /// the Customer product even though the path is global. Use the
+        /// <c>customer</c> filter on <paramref name="options"/> to scope to a single
+        /// customer.
+        /// </summary>
+        Task<MonoStandardResponse<LinkedAccountsResponse>> FetchAllLinkedAccounts(
+            LinkedAccountsQueryOptions options = null,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Updates one or more fields on a customer. All fields on the model are optional.
+        /// </summary>
+        Task<MonoStandardResponse<CustomerResponse>> UpdateCustomer(
+            string id,
+            UpdateCustomerModel model,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Deletes a customer.
+        /// </summary>
+        Task<MonoStandardResponse<dynamic>> DeleteCustomer(
+            string id,
+            CancellationToken cancellationToken = default);
+    }
+}

--- a/Mono.Core/Services/Customers/CustomerService.cs
+++ b/Mono.Core/Services/Customers/CustomerService.cs
@@ -1,0 +1,81 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Mono.Core.Customers
+{
+    public class CustomerService : IMonoCustomers
+    {
+        private readonly ICustomerService _customerService;
+
+        public CustomerService(IRefitClientBuilder<ICustomerService> customerService)
+        {
+            _customerService = customerService.Build(ServiceTypes.Connect);
+        }
+
+        public async Task<MonoStandardResponse<CustomerResponse>> CreateIndividualCustomer(
+            CreateIndividualCustomerModel model,
+            CancellationToken cancellationToken = default)
+        {
+            var response = await _customerService.CreateIndividualCustomer(model, cancellationToken);
+            return response.HandleResponse();
+        }
+
+        public async Task<MonoStandardResponse<CustomerResponse>> CreateBusinessCustomer(
+            CreateBusinessCustomerModel model,
+            CancellationToken cancellationToken = default)
+        {
+            var response = await _customerService.CreateBusinessCustomer(model, cancellationToken);
+            return response.HandleResponse();
+        }
+
+        public async Task<MonoStandardResponse<CustomerResponse>> RetrieveCustomer(
+            string id,
+            CancellationToken cancellationToken = default)
+        {
+            var response = await _customerService.RetrieveCustomer(id, cancellationToken);
+            return response.HandleResponse();
+        }
+
+        public async Task<MonoStandardResponse<CustomerListResponse>> ListCustomers(
+            CustomerListQueryOptions options = null,
+            CancellationToken cancellationToken = default)
+        {
+            var response = await _customerService.ListCustomers(options ?? new CustomerListQueryOptions(), cancellationToken);
+            return response.HandleResponse();
+        }
+
+        public async Task<MonoStandardResponse<CustomerTransactionsResponse>> GetCustomerTransactions(
+            string id,
+            CustomerTransactionsQueryOptions options = null,
+            CancellationToken cancellationToken = default)
+        {
+            var response = await _customerService.GetCustomerTransactions(id, options ?? new CustomerTransactionsQueryOptions(), cancellationToken);
+            return response.HandleResponse();
+        }
+
+        public async Task<MonoStandardResponse<LinkedAccountsResponse>> FetchAllLinkedAccounts(
+            LinkedAccountsQueryOptions options = null,
+            CancellationToken cancellationToken = default)
+        {
+            var response = await _customerService.FetchAllLinkedAccounts(options ?? new LinkedAccountsQueryOptions(), cancellationToken);
+            return response.HandleResponse();
+        }
+
+        public async Task<MonoStandardResponse<CustomerResponse>> UpdateCustomer(
+            string id,
+            UpdateCustomerModel model,
+            CancellationToken cancellationToken = default)
+        {
+            var response = await _customerService.UpdateCustomer(id, model, cancellationToken);
+            return response.HandleResponse();
+        }
+
+        public async Task<MonoStandardResponse<dynamic>> DeleteCustomer(
+            string id,
+            CancellationToken cancellationToken = default)
+        {
+            var response = await _customerService.DeleteCustomer(id, cancellationToken);
+            return response.HandleResponse();
+        }
+    }
+}

--- a/Mono.Core/Services/Customers/Models/CustomerModels.cs
+++ b/Mono.Core/Services/Customers/Models/CustomerModels.cs
@@ -1,0 +1,323 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
+
+namespace Mono.Core.Customers
+{
+    public class CustomerIdentity
+    {
+        [Required]
+        [JsonPropertyName("type")]
+        public string Type { get; set; }
+
+        [Required]
+        [JsonPropertyName("number")]
+        public string Number { get; set; }
+    }
+
+    public class CreateIndividualCustomerModel
+    {
+        [Required]
+        [JsonPropertyName("identity")]
+        public CustomerIdentity Identity { get; set; }
+
+        [Required]
+        [JsonPropertyName("email")]
+        public string Email { get; set; }
+
+        [Required]
+        [JsonPropertyName("type")]
+        public string Type { get; set; } = CustomerTypeConstants.Individual;
+
+        [Required]
+        [JsonPropertyName("first_name")]
+        public string FirstName { get; set; }
+
+        [Required]
+        [JsonPropertyName("last_name")]
+        public string LastName { get; set; }
+
+        [JsonPropertyName("address")]
+        public string Address { get; set; }
+
+        [JsonPropertyName("phone")]
+        public string Phone { get; set; }
+    }
+
+    public class CreateBusinessCustomerModel
+    {
+        [Required]
+        [JsonPropertyName("identity")]
+        public CustomerIdentity Identity { get; set; }
+
+        [Required]
+        [JsonPropertyName("email")]
+        public string Email { get; set; }
+
+        [Required]
+        [JsonPropertyName("type")]
+        public string Type { get; set; } = CustomerTypeConstants.Business;
+
+        [Required]
+        [JsonPropertyName("business_name")]
+        public string BusinessName { get; set; }
+
+        [Required]
+        [JsonPropertyName("address")]
+        public string Address { get; set; }
+
+        [Required]
+        [JsonPropertyName("phone")]
+        public string Phone { get; set; }
+    }
+
+    public class UpdateCustomerModel
+    {
+        [JsonPropertyName("identity")]
+        public CustomerIdentity Identity { get; set; }
+
+        [JsonPropertyName("address")]
+        public string Address { get; set; }
+
+        [JsonPropertyName("phone")]
+        public string Phone { get; set; }
+
+        [JsonPropertyName("type")]
+        public string Type { get; set; }
+
+        [JsonPropertyName("first_name")]
+        public string FirstName { get; set; }
+
+        [JsonPropertyName("last_name")]
+        public string LastName { get; set; }
+
+        [JsonPropertyName("business_name")]
+        public string BusinessName { get; set; }
+    }
+
+    public class CustomerListQueryOptions
+    {
+        [JsonPropertyName("page")]
+        public int? Page { get; set; }
+
+        [JsonPropertyName("limit")]
+        public int? Limit { get; set; }
+
+        [JsonPropertyName("phone")]
+        public string Phone { get; set; }
+
+        [JsonPropertyName("first_name")]
+        public string FirstName { get; set; }
+
+        [JsonPropertyName("last_name")]
+        public string LastName { get; set; }
+
+        [JsonPropertyName("start")]
+        public string Start { get; set; }
+
+        [JsonPropertyName("end")]
+        public string End { get; set; }
+    }
+
+    public class CustomerTransactionsQueryOptions
+    {
+        [JsonPropertyName("period")]
+        public string Period { get; set; }
+
+        [JsonPropertyName("page")]
+        public int? Page { get; set; }
+
+        [JsonPropertyName("account")]
+        public string Account { get; set; }
+    }
+
+    public class LinkedAccountsQueryOptions
+    {
+        [JsonPropertyName("page")]
+        public int? Page { get; set; }
+
+        [JsonPropertyName("limit")]
+        public int? Limit { get; set; }
+
+        [JsonPropertyName("customer")]
+        public string Customer { get; set; }
+
+        [JsonPropertyName("institution")]
+        public string Institution { get; set; }
+    }
+
+    public class CustomerResponse
+    {
+        [JsonPropertyName("id")]
+        public string Id { get; set; }
+
+        [JsonPropertyName("email")]
+        public string Email { get; set; }
+
+        [JsonPropertyName("type")]
+        public string Type { get; set; }
+
+        [JsonPropertyName("identity")]
+        public CustomerIdentity Identity { get; set; }
+
+        [JsonPropertyName("first_name")]
+        public string FirstName { get; set; }
+
+        [JsonPropertyName("last_name")]
+        public string LastName { get; set; }
+
+        [JsonPropertyName("business_name")]
+        public string BusinessName { get; set; }
+
+        [JsonPropertyName("address")]
+        public string Address { get; set; }
+
+        [JsonPropertyName("phone")]
+        public string Phone { get; set; }
+
+        [JsonPropertyName("created_at")]
+        public DateTime? CreatedAt { get; set; }
+
+        [JsonPropertyName("updated_at")]
+        public DateTime? UpdatedAt { get; set; }
+    }
+
+    public class CustomerListResponse
+    {
+        [JsonPropertyName("customers")]
+        public List<CustomerResponse> Customers { get; set; }
+
+        [JsonPropertyName("meta")]
+        public CustomerListMeta Meta { get; set; }
+    }
+
+    public class CustomerListMeta
+    {
+        [JsonPropertyName("total")]
+        public long Total { get; set; }
+
+        [JsonPropertyName("page")]
+        public long Page { get; set; }
+
+        [JsonPropertyName("previous")]
+        public string Previous { get; set; }
+
+        [JsonPropertyName("next")]
+        public string Next { get; set; }
+    }
+
+    public class CustomerTransaction
+    {
+        [JsonPropertyName("id")]
+        public string Id { get; set; }
+
+        [JsonPropertyName("reference")]
+        public string Reference { get; set; }
+
+        [JsonPropertyName("type")]
+        public string Type { get; set; }
+
+        [JsonPropertyName("amount")]
+        public long Amount { get; set; }
+
+        [JsonPropertyName("currency")]
+        public string Currency { get; set; }
+
+        [JsonPropertyName("status")]
+        public string Status { get; set; }
+
+        [JsonPropertyName("narration")]
+        public string Narration { get; set; }
+
+        [JsonPropertyName("account")]
+        public string Account { get; set; }
+
+        [JsonPropertyName("customer")]
+        public string Customer { get; set; }
+
+        [JsonPropertyName("created_at")]
+        public DateTime? CreatedAt { get; set; }
+
+        [JsonPropertyName("updated_at")]
+        public DateTime? UpdatedAt { get; set; }
+    }
+
+    public class CustomerTransactionsResponse
+    {
+        [JsonPropertyName("transactions")]
+        public List<CustomerTransaction> Transactions { get; set; }
+
+        [JsonPropertyName("meta")]
+        public CustomerListMeta Meta { get; set; }
+    }
+
+    public class LinkedAccountSummary
+    {
+        [JsonPropertyName("id")]
+        public string Id { get; set; }
+
+        [JsonPropertyName("name")]
+        public string Name { get; set; }
+
+        [JsonPropertyName("account_number")]
+        public string AccountNumber { get; set; }
+
+        [JsonPropertyName("type")]
+        public string Type { get; set; }
+
+        [JsonPropertyName("currency")]
+        public string Currency { get; set; }
+
+        [JsonPropertyName("balance")]
+        public long? Balance { get; set; }
+
+        [JsonPropertyName("bvn")]
+        public string Bvn { get; set; }
+
+        [JsonPropertyName("institution")]
+        public LinkedAccountInstitution Institution { get; set; }
+
+        [JsonPropertyName("customer")]
+        public string Customer { get; set; }
+
+        [JsonPropertyName("created_at")]
+        public DateTime? CreatedAt { get; set; }
+
+        [JsonPropertyName("updated_at")]
+        public DateTime? UpdatedAt { get; set; }
+    }
+
+    public class LinkedAccountInstitution
+    {
+        [JsonPropertyName("name")]
+        public string Name { get; set; }
+
+        [JsonPropertyName("bank_code")]
+        public string BankCode { get; set; }
+
+        [JsonPropertyName("type")]
+        public string Type { get; set; }
+    }
+
+    public class LinkedAccountsResponse
+    {
+        [JsonPropertyName("accounts")]
+        public List<LinkedAccountSummary> Accounts { get; set; }
+
+        [JsonPropertyName("meta")]
+        public CustomerListMeta Meta { get; set; }
+    }
+
+    public class CustomerTypeConstants
+    {
+        public const string Individual = "individual";
+        public const string Business = "business";
+    }
+
+    public class CustomerIdentityTypeConstants
+    {
+        public const string Bvn = "bvn";
+        public const string Nin = "nin";
+    }
+}

--- a/Readme.md
+++ b/Readme.md
@@ -8,6 +8,7 @@ Mono.Core is a .NET library that provides services and utilities for Mono accoun
 
 - [IMonoAccounts](#imonoaccounts)
 - [IMonoAuthorization](#imonoauthorization)
+- [IMonoCustomers](#imonocustomers)
 - [IMonoDirectPay](#imonodirectpay)
 - [IMonoLookUp](#imonolookup)
 - [IMonoMiscellaneous](#imonomiscellaneous)
@@ -162,6 +163,36 @@ This interface provides methods for managing authorization in Mono.
 - `SyncAccount`This method is used to sync specific account manually.
 - `ReauthorizeAccount` This method is use to reauthorise a specific previously linked account.
 
+### IMonoCustomers
+
+This interface wraps the Mono Customer API (`/v2/customers`). Use it to model customers in your business and tie linked accounts and payment transactions to them.
+
+- `CreateIndividualCustomer` Creates an individual customer (first name + last name).
+- `CreateBusinessCustomer` Creates a business customer (business name + required address/phone).
+- `RetrieveCustomer` Fetches a single customer by id.
+- `ListCustomers` Lists customers with optional pagination and name/phone/date filters.
+- `GetCustomerTransactions` Lists transactions performed by a customer across Mono's payment products. Supports `period`, `page`, and linked-account scoping.
+- `FetchAllLinkedAccounts` Lists every bank account linked to your business. Filter by `customer` to scope to one customer.
+- `UpdateCustomer` Partially updates a customer; every field on the model is optional.
+- `DeleteCustomer` Deletes a customer.
+
+```csharp
+using Mono.Core.Customers;
+
+var customer = await _customers.CreateIndividualCustomer(new CreateIndividualCustomerModel
+{
+    FirstName = "Ada",
+    LastName = "Lovelace",
+    Email = "ada@example.com",
+    Phone = "+2348012345678",
+    Identity = new CustomerIdentity
+    {
+        Type = CustomerIdentityTypeConstants.Bvn,
+        Number = "12345678901",
+    },
+});
+```
+
 ### IMonoDirectPay
 
 This interface provides methods for managing direct pay in Mono.
@@ -200,6 +231,28 @@ This interface provides miscellaneous methods for managing Mono.
 - `GetCacLookup` This method to retieve cac lookup information.
 - `GetCacCompany` This method is use to retrieve shareholder information of a company.
 - `UnLinkAccount` This method provide you with the option to unlink their financial account(s).
+
+## Changes in 1.2.0 (May 2026)
+
+Adds the Mono Customer API surface. Customers let you model your end users, attach linked bank accounts to them, and pull transaction history per customer.
+
+**New `IMonoCustomers` interface — eight endpoints under `/v2/customers`:**
+- `CreateIndividualCustomer` (POST `/customers`, `type=individual`)
+- `CreateBusinessCustomer` (POST `/customers`, `type=business`)
+- `RetrieveCustomer` (GET `/customers/{id}`)
+- `ListCustomers` (GET `/customers`, paginated)
+- `GetCustomerTransactions` (GET `/customers/{id}/transactions`)
+- `FetchAllLinkedAccounts` (GET `/accounts` — Mono files this under Customer)
+- `UpdateCustomer` (PATCH `/customers/{id}`, all fields optional)
+- `DeleteCustomer` (DELETE `/customers/{id}`)
+
+**Registration:**
+- `AddMono(...)` now also wires up `IMonoCustomers`
+- Standalone `AddMonoCustomers(...)` extension available for service-by-service registration
+
+**Constants:**
+- `CustomerTypeConstants` (`individual` / `business`)
+- `CustomerIdentityTypeConstants` (`bvn` / `nin`)
 
 ## Changes in 1.1.0 (May 2026)
 


### PR DESCRIPTION
## Summary

Adds the Mono **Customer API** (added by Mono in March 2024). Customers are the unit you tie linked accounts and payment transactions to — without them, you can't take meaningful advantage of the per-customer features Mono added over the last two years.

This is the first of the follow-up PRs to the 1.1.0 drift refresh.

## New surface — `IMonoCustomers`

| Method | Endpoint | Notes |
|---|---|---|
| `CreateIndividualCustomer` | POST `/customers` | `type=individual`, `first_name` + `last_name` required |
| `CreateBusinessCustomer` | POST `/customers` | `type=business`, `business_name` + `address` + `phone` required |
| `RetrieveCustomer` | GET `/customers/{id}` | |
| `ListCustomers` | GET `/customers` | Paginated; filter by `phone`, `first_name`, `last_name`, `start`, `end` |
| `GetCustomerTransactions` | GET `/customers/{id}/transactions` | Filter by `period`, `page`, `account` |
| `FetchAllLinkedAccounts` | GET `/accounts` | Mono files this under Customer; filter by `customer` to scope |
| `UpdateCustomer` | PATCH `/customers/{id}` | All fields optional |
| `DeleteCustomer` | DELETE `/customers/{id}` | |

Two `POST /customers` Refit methods share the same path but take different body types — `CreateIndividualCustomerModel` and `CreateBusinessCustomerModel`. This gives callers strongly-typed creation paths instead of a single grab-bag DTO with half the fields nullable depending on type.

## DI

- `AddMono(...)` now also registers `IMonoCustomers`
- Standalone `AddMonoCustomers(...)` follows the existing per-service registration pattern

## Constants

- `CustomerTypeConstants` — `individual` / `business`
- `CustomerIdentityTypeConstants` — `bvn` / `nin`

## Code layout

Follows the existing `Services/<Product>/` convention:

```
Mono.Core/Services/Customers/
├── Abstractions/
│   ├── ICustomerService.cs   (Refit interface)
│   └── IMonoCustomers.cs      (high-level interface)
├── Models/
│   └── CustomerModels.cs       (requests, responses, constants)
└── CustomerService.cs           (high-level implementation)
```

Uses `ServiceTypes.Connect` for the secret key (matches the Mono Connect product key).

## Compat

- Pure additive — no existing interface or method changed
- Package version: 1.1.0 → 1.2.0 (minor bump)

## Test plan

- [x] `dotnet build` — succeeds, no new warnings
- [x] Refit interface follows the same `IApiResponse<MonoStandardResponse<T>>` shape as every other service so `HandleResponse()` works uniformly
- [ ] Smoke-test against Mono sandbox before NuGet publish: create individual, create business, retrieve, list, transactions, linked accounts, update, delete
- [ ] Verify list/transactions/linked-accounts response shapes — Mono's docs didn't expose full 200 schemas; current `CustomerListResponse` / `LinkedAccountsResponse` assume a `data` wrapper + `meta` paging block (consistent with other Mono list endpoints). Adjust if the sandbox returns a flat array.

## Follow-up PRs still queued

Per the drift PR plan: Disburse, Watchlist Screening, Prove, Connect additions (real-time `account-balance`, Account Match, Get-All-Accounts at the Account layer), NIN Poll-Job, CAC PSC/Profile/Status-Report, DirectPay Refund/Payout, webhook hardening (`mono-webhook-secret` verification + new event types).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce a new Mono Customers service surface and wire it into the core library and documentation for version 1.2.0.

New Features:
- Add IMonoCustomers high-level interface and CustomerService implementation for working with Mono's v2 Customer API.
- Define strongly-typed request/response models, query options, and constants for creating, updating, listing, and deleting customers, retrieving customer transactions, and fetching linked accounts.
- Expose a dedicated AddMonoCustomers(...) DI registration method and include IMonoCustomers in the main AddMono(...) registration pipeline.

Documentation:
- Extend the README with IMonoCustomers usage documentation, endpoint overview, example code, and a new 1.2.0 changelog section describing the Customer API additions.