### PR TITLE
Add Mono Disburse API surface (v1.3.0)

### DIFF
--- a/Mono.Core/Extensions/IServiceCollectionExtension.cs
+++ b/Mono.Core/Extensions/IServiceCollectionExtension.cs
@@ -5,6 +5,7 @@ using Mono.Core.Accounts;
 using Mono.Core.Authorization;
 using Mono.Core.Customers;
 using Mono.Core.DirectPay;
+using Mono.Core.Disburse;
 using Mono.Core.LookUp;
 using Mono.Core.Miscellaneous; // Add this using directive
 
@@ -22,6 +23,7 @@ namespace Mono.Core
             services.AddTransient<IMonoMiscellaneous, MiscellaneousService>(); // Add this line
             services.AddTransient<IMonoLookUp, LookUpService>();
             services.AddTransient<IMonoCustomers, CustomerService>();
+            services.AddTransient<IMonoDisburse, DisburseService>();
             return services;
         }
 
@@ -70,6 +72,14 @@ namespace Mono.Core
             services.Configure(options);
             services.AddTransient(typeof(IRefitClientBuilder<>), typeof(RefitClientBuilder<>));
             services.AddTransient<IMonoCustomers, CustomerService>();
+            return services;
+        }
+
+        public static IServiceCollection AddMonoDisburse(this IServiceCollection services, Action<MonoInitializationOptions> options)
+        {
+            services.Configure(options);
+            services.AddTransient(typeof(IRefitClientBuilder<>), typeof(RefitClientBuilder<>));
+            services.AddTransient<IMonoDisburse, DisburseService>();
             return services;
         }
 

--- a/Mono.Core/Mono.Core.csproj
+++ b/Mono.Core/Mono.Core.csproj
@@ -5,7 +5,7 @@
 			Mono.Core
 		</PackageId>
 		<Version>
-			1.2.0
+			1.3.0
 		</Version>
 		<Authors>
 			Adelowomi

--- a/Mono.Core/Services/Disburse/Abstractions/IDisburseService.cs
+++ b/Mono.Core/Services/Disburse/Abstractions/IDisburseService.cs
@@ -1,0 +1,92 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Refit;
+
+namespace Mono.Core.Disburse
+{
+    // Refit interface for the Mono Disburse API (v3). The high-level
+    // IMonoDisburse facade wraps these calls and unwraps the response.
+    // BaseUrl carries /v2/; the RefitClientBuilder.BuildV3() override
+    // rewrites it to /v3/ before requests go out, so paths here omit
+    // the version prefix.
+    public interface IDisburseService
+    {
+        // -------- Source accounts --------
+
+        [Post("/payments/disburse/source-accounts")]
+        Task<IApiResponse<MonoStandardResponse<SourceAccountResponse>>> CreateSourceAccount(
+            [Body] CreateSourceAccountModel model,
+            CancellationToken cancellationToken = default);
+
+        [Put("/payments/disburse/source-accounts")]
+        Task<IApiResponse<MonoStandardResponse<SourceAccountResponse>>> UpdateSourceAccount(
+            [Body] UpdateSourceAccountModel model,
+            CancellationToken cancellationToken = default);
+
+        [Get("/payments/disburse/source-accounts")]
+        Task<IApiResponse<MonoStandardResponse<SourceAccountListResponse>>> FetchAllSourceAccounts(
+            [Query] SourceAccountListQueryOptions options,
+            CancellationToken cancellationToken = default);
+
+        [Get("/payments/disburse/source-accounts/{id}")]
+        Task<IApiResponse<MonoStandardResponse<SourceAccountResponse>>> FetchSourceAccount(
+            string id,
+            CancellationToken cancellationToken = default);
+
+        // -------- Disbursements (batches) --------
+
+        [Post("/payments/disburse/disbursements")]
+        Task<IApiResponse<MonoStandardResponse<DisbursementResponse>>> CreateDisbursement(
+            [Body] CreateDisbursementModel model,
+            CancellationToken cancellationToken = default);
+
+        [Post("/payments/disburse/disbursements/{id}/transition")]
+        Task<IApiResponse<MonoStandardResponse<DisbursementResponse>>> TransitionDisbursement(
+            string id,
+            [Body] TransitionDisbursementModel model,
+            CancellationToken cancellationToken = default);
+
+        [Get("/payments/disburse/disbursements")]
+        Task<IApiResponse<MonoStandardResponse<DisbursementListResponse>>> FetchAllDisbursements(
+            [Query] DisbursementListQueryOptions options,
+            CancellationToken cancellationToken = default);
+
+        [Get("/payments/disburse/disbursements/{id}")]
+        Task<IApiResponse<MonoStandardResponse<DisbursementResponse>>> FetchDisbursement(
+            string id,
+            CancellationToken cancellationToken = default);
+
+        // -------- Distributions inside a batch --------
+
+        [Post("/payments/disburse/disbursements/{id}/distributions")]
+        Task<IApiResponse<MonoStandardResponse<DistributionListResponse>>> AddDistributionsToBatch(
+            string id,
+            [Body] AddDistributionsModel model,
+            CancellationToken cancellationToken = default);
+
+        [Patch("/payments/disburse/disbursements/{id}/distributions/{distributionId}")]
+        Task<IApiResponse<MonoStandardResponse<DistributionResponse>>> UpdateDistributionInBatch(
+            string id,
+            string distributionId,
+            [Body] UpdateDistributionModel model,
+            CancellationToken cancellationToken = default);
+
+        [Delete("/payments/disburse/disbursements/{id}/distributions/{distributionId}")]
+        Task<IApiResponse<MonoStandardResponse<dynamic>>> DeleteDistributionInBatch(
+            string id,
+            string distributionId,
+            CancellationToken cancellationToken = default);
+
+        [Get("/payments/disburse/disbursements/{id}/distributions")]
+        Task<IApiResponse<MonoStandardResponse<DistributionListResponse>>> FetchAllDistributionsInBatch(
+            string id,
+            [Query] DistributionListQueryOptions options,
+            CancellationToken cancellationToken = default);
+
+        [Get("/payments/disburse/disbursements/{id}/distributions/{distributionId}")]
+        Task<IApiResponse<MonoStandardResponse<DistributionResponse>>> FetchSingleDistribution(
+            string id,
+            string distributionId,
+            CancellationToken cancellationToken = default);
+    }
+}

--- a/Mono.Core/Services/Disburse/Abstractions/IMonoDisburse.cs
+++ b/Mono.Core/Services/Disburse/Abstractions/IMonoDisburse.cs
@@ -1,0 +1,134 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Mono.Core.Disburse
+{
+    public interface IMonoDisburse
+    {
+        // -------- Source accounts --------
+
+        /// <summary>
+        /// Registers a bank account that will fund subsequent disbursements.
+        /// </summary>
+        Task<MonoStandardResponse<SourceAccountResponse>> CreateSourceAccount(
+            CreateSourceAccountModel model,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Updates a previously registered source account. Only the fields you
+        /// set on <paramref name="model"/> are sent.
+        /// </summary>
+        Task<MonoStandardResponse<SourceAccountResponse>> UpdateSourceAccount(
+            UpdateSourceAccountModel model,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Lists every source account registered for this business.
+        /// </summary>
+        Task<MonoStandardResponse<SourceAccountListResponse>> FetchAllSourceAccounts(
+            SourceAccountListQueryOptions options = null,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Fetches a single source account by id.
+        /// </summary>
+        Task<MonoStandardResponse<SourceAccountResponse>> FetchSourceAccount(
+            string id,
+            CancellationToken cancellationToken = default);
+
+        // -------- Disbursements (batches) --------
+
+        /// <summary>
+        /// Creates a disbursement batch. Set <see cref="CreateDisbursementModel.Type"/>
+        /// to <c>"instant"</c> (executes immediately) or <c>"scheduled"</c> (executes on
+        /// <see cref="CreateDisbursementModel.ScheduledDate"/>). Mono uses the same
+        /// endpoint for both — only the body differs.
+        /// </summary>
+        Task<MonoStandardResponse<DisbursementResponse>> CreateDisbursement(
+            CreateDisbursementModel model,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Convenience wrapper that creates an instant disbursement. Sets
+        /// <c>type=instant</c> on <paramref name="model"/>.
+        /// </summary>
+        Task<MonoStandardResponse<DisbursementResponse>> CreateInstantDisbursement(
+            CreateDisbursementModel model,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Convenience wrapper that creates a scheduled disbursement. Sets
+        /// <c>type=scheduled</c> on <paramref name="model"/>; ensure
+        /// <see cref="CreateDisbursementModel.ScheduledDate"/> is populated.
+        /// </summary>
+        Task<MonoStandardResponse<DisbursementResponse>> CreateScheduledDisbursement(
+            CreateDisbursementModel model,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Transitions a scheduled disbursement. <c>action=trigger</c> executes it
+        /// immediately; <c>action=cancel</c> cancels it.
+        /// </summary>
+        Task<MonoStandardResponse<DisbursementResponse>> TransitionDisbursement(
+            string id,
+            TransitionDisbursementModel model,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Lists every disbursement batch for this business.
+        /// </summary>
+        Task<MonoStandardResponse<DisbursementListResponse>> FetchAllDisbursements(
+            DisbursementListQueryOptions options = null,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Fetches a single disbursement batch by id.
+        /// </summary>
+        Task<MonoStandardResponse<DisbursementResponse>> FetchDisbursement(
+            string id,
+            CancellationToken cancellationToken = default);
+
+        // -------- Distributions inside a batch --------
+
+        /// <summary>
+        /// Adds one or more distributions to an existing disbursement batch.
+        /// </summary>
+        Task<MonoStandardResponse<DistributionListResponse>> AddDistributionsToBatch(
+            string disbursementId,
+            AddDistributionsModel model,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Updates a distribution within a batch. All fields on the model are optional.
+        /// </summary>
+        Task<MonoStandardResponse<DistributionResponse>> UpdateDistributionInBatch(
+            string disbursementId,
+            string distributionId,
+            UpdateDistributionModel model,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Removes a distribution from a batch.
+        /// </summary>
+        Task<MonoStandardResponse<dynamic>> DeleteDistributionInBatch(
+            string disbursementId,
+            string distributionId,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Lists every distribution attached to a batch.
+        /// </summary>
+        Task<MonoStandardResponse<DistributionListResponse>> FetchAllDistributionsInBatch(
+            string disbursementId,
+            DistributionListQueryOptions options = null,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Fetches a single distribution from a batch by id.
+        /// </summary>
+        Task<MonoStandardResponse<DistributionResponse>> FetchSingleDistribution(
+            string disbursementId,
+            string distributionId,
+            CancellationToken cancellationToken = default);
+    }
+}

--- a/Mono.Core/Services/Disburse/DisburseService.cs
+++ b/Mono.Core/Services/Disburse/DisburseService.cs
@@ -1,0 +1,149 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Mono.Core.Disburse
+{
+    public class DisburseService : IMonoDisburse
+    {
+        private readonly IDisburseService _disburseService;
+
+        public DisburseService(IRefitClientBuilder<IDisburseService> disburseService)
+        {
+            // All Disburse endpoints live under /v3/.
+            _disburseService = disburseService.BuildV3();
+        }
+
+        // -------- Source accounts --------
+
+        public async Task<MonoStandardResponse<SourceAccountResponse>> CreateSourceAccount(
+            CreateSourceAccountModel model,
+            CancellationToken cancellationToken = default)
+        {
+            var response = await _disburseService.CreateSourceAccount(model, cancellationToken);
+            return response.HandleResponse();
+        }
+
+        public async Task<MonoStandardResponse<SourceAccountResponse>> UpdateSourceAccount(
+            UpdateSourceAccountModel model,
+            CancellationToken cancellationToken = default)
+        {
+            var response = await _disburseService.UpdateSourceAccount(model, cancellationToken);
+            return response.HandleResponse();
+        }
+
+        public async Task<MonoStandardResponse<SourceAccountListResponse>> FetchAllSourceAccounts(
+            SourceAccountListQueryOptions options = null,
+            CancellationToken cancellationToken = default)
+        {
+            var response = await _disburseService.FetchAllSourceAccounts(options ?? new SourceAccountListQueryOptions(), cancellationToken);
+            return response.HandleResponse();
+        }
+
+        public async Task<MonoStandardResponse<SourceAccountResponse>> FetchSourceAccount(
+            string id,
+            CancellationToken cancellationToken = default)
+        {
+            var response = await _disburseService.FetchSourceAccount(id, cancellationToken);
+            return response.HandleResponse();
+        }
+
+        // -------- Disbursements (batches) --------
+
+        public async Task<MonoStandardResponse<DisbursementResponse>> CreateDisbursement(
+            CreateDisbursementModel model,
+            CancellationToken cancellationToken = default)
+        {
+            var response = await _disburseService.CreateDisbursement(model, cancellationToken);
+            return response.HandleResponse();
+        }
+
+        public Task<MonoStandardResponse<DisbursementResponse>> CreateInstantDisbursement(
+            CreateDisbursementModel model,
+            CancellationToken cancellationToken = default)
+        {
+            model.Type = DisbursementTypeConstants.Instant;
+            return CreateDisbursement(model, cancellationToken);
+        }
+
+        public Task<MonoStandardResponse<DisbursementResponse>> CreateScheduledDisbursement(
+            CreateDisbursementModel model,
+            CancellationToken cancellationToken = default)
+        {
+            model.Type = DisbursementTypeConstants.Scheduled;
+            return CreateDisbursement(model, cancellationToken);
+        }
+
+        public async Task<MonoStandardResponse<DisbursementResponse>> TransitionDisbursement(
+            string id,
+            TransitionDisbursementModel model,
+            CancellationToken cancellationToken = default)
+        {
+            var response = await _disburseService.TransitionDisbursement(id, model, cancellationToken);
+            return response.HandleResponse();
+        }
+
+        public async Task<MonoStandardResponse<DisbursementListResponse>> FetchAllDisbursements(
+            DisbursementListQueryOptions options = null,
+            CancellationToken cancellationToken = default)
+        {
+            var response = await _disburseService.FetchAllDisbursements(options ?? new DisbursementListQueryOptions(), cancellationToken);
+            return response.HandleResponse();
+        }
+
+        public async Task<MonoStandardResponse<DisbursementResponse>> FetchDisbursement(
+            string id,
+            CancellationToken cancellationToken = default)
+        {
+            var response = await _disburseService.FetchDisbursement(id, cancellationToken);
+            return response.HandleResponse();
+        }
+
+        // -------- Distributions inside a batch --------
+
+        public async Task<MonoStandardResponse<DistributionListResponse>> AddDistributionsToBatch(
+            string disbursementId,
+            AddDistributionsModel model,
+            CancellationToken cancellationToken = default)
+        {
+            var response = await _disburseService.AddDistributionsToBatch(disbursementId, model, cancellationToken);
+            return response.HandleResponse();
+        }
+
+        public async Task<MonoStandardResponse<DistributionResponse>> UpdateDistributionInBatch(
+            string disbursementId,
+            string distributionId,
+            UpdateDistributionModel model,
+            CancellationToken cancellationToken = default)
+        {
+            var response = await _disburseService.UpdateDistributionInBatch(disbursementId, distributionId, model, cancellationToken);
+            return response.HandleResponse();
+        }
+
+        public async Task<MonoStandardResponse<dynamic>> DeleteDistributionInBatch(
+            string disbursementId,
+            string distributionId,
+            CancellationToken cancellationToken = default)
+        {
+            var response = await _disburseService.DeleteDistributionInBatch(disbursementId, distributionId, cancellationToken);
+            return response.HandleResponse();
+        }
+
+        public async Task<MonoStandardResponse<DistributionListResponse>> FetchAllDistributionsInBatch(
+            string disbursementId,
+            DistributionListQueryOptions options = null,
+            CancellationToken cancellationToken = default)
+        {
+            var response = await _disburseService.FetchAllDistributionsInBatch(disbursementId, options ?? new DistributionListQueryOptions(), cancellationToken);
+            return response.HandleResponse();
+        }
+
+        public async Task<MonoStandardResponse<DistributionResponse>> FetchSingleDistribution(
+            string disbursementId,
+            string distributionId,
+            CancellationToken cancellationToken = default)
+        {
+            var response = await _disburseService.FetchSingleDistribution(disbursementId, distributionId, cancellationToken);
+            return response.HandleResponse();
+        }
+    }
+}

--- a/Mono.Core/Services/Disburse/Models/DisburseModels.cs
+++ b/Mono.Core/Services/Disburse/Models/DisburseModels.cs
@@ -1,0 +1,385 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
+
+namespace Mono.Core.Disburse
+{
+    // ============ Source accounts ============
+
+    public class CreateSourceAccountModel
+    {
+        [Required]
+        [JsonPropertyName("app")]
+        public string App { get; set; }
+
+        [Required]
+        [JsonPropertyName("account_number")]
+        public string AccountNumber { get; set; }
+
+        [Required]
+        [JsonPropertyName("bank_code")]
+        public string BankCode { get; set; }
+
+        [Required]
+        [JsonPropertyName("email")]
+        public string Email { get; set; }
+    }
+
+    public class UpdateSourceAccountModel
+    {
+        [Required]
+        [JsonPropertyName("id")]
+        public string Id { get; set; }
+
+        [JsonPropertyName("account_number")]
+        public string AccountNumber { get; set; }
+
+        [JsonPropertyName("bank_code")]
+        public string BankCode { get; set; }
+
+        [JsonPropertyName("email")]
+        public string Email { get; set; }
+    }
+
+    public class SourceAccountResponse
+    {
+        [JsonPropertyName("id")]
+        public string Id { get; set; }
+
+        [JsonPropertyName("app")]
+        public string App { get; set; }
+
+        [JsonPropertyName("account_number")]
+        public string AccountNumber { get; set; }
+
+        [JsonPropertyName("bank_code")]
+        public string BankCode { get; set; }
+
+        [JsonPropertyName("account_name")]
+        public string AccountName { get; set; }
+
+        [JsonPropertyName("email")]
+        public string Email { get; set; }
+
+        [JsonPropertyName("status")]
+        public string Status { get; set; }
+
+        [JsonPropertyName("balance")]
+        public long? Balance { get; set; }
+
+        [JsonPropertyName("currency")]
+        public string Currency { get; set; }
+
+        [JsonPropertyName("created_at")]
+        public DateTime? CreatedAt { get; set; }
+
+        [JsonPropertyName("updated_at")]
+        public DateTime? UpdatedAt { get; set; }
+    }
+
+    public class SourceAccountListResponse
+    {
+        [JsonPropertyName("source_accounts")]
+        public List<SourceAccountResponse> SourceAccounts { get; set; }
+
+        [JsonPropertyName("meta")]
+        public DisbursePaginationMeta Meta { get; set; }
+    }
+
+    public class SourceAccountListQueryOptions
+    {
+        [JsonPropertyName("page")]
+        public int? Page { get; set; }
+
+        [JsonPropertyName("limit")]
+        public int? Limit { get; set; }
+
+        [JsonPropertyName("status")]
+        public string Status { get; set; }
+    }
+
+    // ============ Disbursements (batches) ============
+
+    public class DisbursementRecipientAccount
+    {
+        [Required]
+        [JsonPropertyName("account_number")]
+        public string AccountNumber { get; set; }
+
+        [Required]
+        [JsonPropertyName("bank_code")]
+        public string BankCode { get; set; }
+    }
+
+    public class DistributionModel
+    {
+        [Required]
+        [JsonPropertyName("reference")]
+        public string Reference { get; set; }
+
+        [Required]
+        [JsonPropertyName("recipient_email")]
+        public string RecipientEmail { get; set; }
+
+        [Required]
+        [JsonPropertyName("account")]
+        public DisbursementRecipientAccount Account { get; set; }
+
+        [Required]
+        [JsonPropertyName("amount")]
+        public long Amount { get; set; }
+
+        [Required]
+        [JsonPropertyName("narration")]
+        public string Narration { get; set; }
+    }
+
+    public class CreateDisbursementModel
+    {
+        [Required]
+        [JsonPropertyName("reference")]
+        public string Reference { get; set; }
+
+        /// <summary>Funding source. Currently "mandate".</summary>
+        [Required]
+        [JsonPropertyName("source")]
+        public string Source { get; set; } = DisbursementSourceConstants.Mandate;
+
+        /// <summary>Source account id (from <see cref="SourceAccountResponse.Id"/>).</summary>
+        [Required]
+        [JsonPropertyName("account")]
+        public string Account { get; set; }
+
+        /// <summary>"instant" or "scheduled".</summary>
+        [Required]
+        [JsonPropertyName("type")]
+        public string Type { get; set; }
+
+        [Required]
+        [JsonPropertyName("total_amount")]
+        public long TotalAmount { get; set; }
+
+        [Required]
+        [JsonPropertyName("description")]
+        public string Description { get; set; }
+
+        /// <summary>Scheduled execution date (ISO-8601). Required when <see cref="Type"/> is "scheduled".</summary>
+        [JsonPropertyName("scheduled_date")]
+        public string ScheduledDate { get; set; }
+
+        [Required]
+        [JsonPropertyName("distribution")]
+        public List<DistributionModel> Distribution { get; set; }
+    }
+
+    public class TransitionDisbursementModel
+    {
+        /// <summary>"trigger" or "cancel".</summary>
+        [Required]
+        [JsonPropertyName("action")]
+        public string Action { get; set; }
+    }
+
+    public class DisbursementResponse
+    {
+        [JsonPropertyName("id")]
+        public string Id { get; set; }
+
+        [JsonPropertyName("reference")]
+        public string Reference { get; set; }
+
+        [JsonPropertyName("source")]
+        public string Source { get; set; }
+
+        [JsonPropertyName("account")]
+        public string Account { get; set; }
+
+        [JsonPropertyName("type")]
+        public string Type { get; set; }
+
+        [JsonPropertyName("status")]
+        public string Status { get; set; }
+
+        [JsonPropertyName("total_amount")]
+        public long TotalAmount { get; set; }
+
+        [JsonPropertyName("currency")]
+        public string Currency { get; set; }
+
+        [JsonPropertyName("description")]
+        public string Description { get; set; }
+
+        [JsonPropertyName("scheduled_date")]
+        public DateTime? ScheduledDate { get; set; }
+
+        [JsonPropertyName("processed_at")]
+        public DateTime? ProcessedAt { get; set; }
+
+        [JsonPropertyName("distribution_count")]
+        public long? DistributionCount { get; set; }
+
+        [JsonPropertyName("app")]
+        public string App { get; set; }
+
+        [JsonPropertyName("business")]
+        public string Business { get; set; }
+
+        [JsonPropertyName("created_at")]
+        public DateTime? CreatedAt { get; set; }
+
+        [JsonPropertyName("updated_at")]
+        public DateTime? UpdatedAt { get; set; }
+    }
+
+    public class DisbursementListResponse
+    {
+        [JsonPropertyName("disbursements")]
+        public List<DisbursementResponse> Disbursements { get; set; }
+
+        [JsonPropertyName("meta")]
+        public DisbursePaginationMeta Meta { get; set; }
+    }
+
+    public class DisbursementListQueryOptions
+    {
+        [JsonPropertyName("page")]
+        public int? Page { get; set; }
+
+        [JsonPropertyName("limit")]
+        public int? Limit { get; set; }
+
+        [JsonPropertyName("status")]
+        public string Status { get; set; }
+
+        [JsonPropertyName("type")]
+        public string Type { get; set; }
+
+        [JsonPropertyName("start")]
+        public string Start { get; set; }
+
+        [JsonPropertyName("end")]
+        public string End { get; set; }
+    }
+
+    // ============ Distributions inside a batch ============
+
+    public class AddDistributionsModel
+    {
+        [Required]
+        [JsonPropertyName("distribution")]
+        public List<DistributionModel> Distribution { get; set; }
+    }
+
+    public class UpdateDistributionModel
+    {
+        [JsonPropertyName("recipient_email")]
+        public string RecipientEmail { get; set; }
+
+        [JsonPropertyName("account")]
+        public DisbursementRecipientAccount Account { get; set; }
+
+        [JsonPropertyName("amount")]
+        public long? Amount { get; set; }
+
+        [JsonPropertyName("narration")]
+        public string Narration { get; set; }
+    }
+
+    public class DistributionResponse
+    {
+        [JsonPropertyName("id")]
+        public string Id { get; set; }
+
+        [JsonPropertyName("reference")]
+        public string Reference { get; set; }
+
+        [JsonPropertyName("disbursement")]
+        public string Disbursement { get; set; }
+
+        [JsonPropertyName("recipient_email")]
+        public string RecipientEmail { get; set; }
+
+        [JsonPropertyName("account")]
+        public DisbursementRecipientAccount Account { get; set; }
+
+        [JsonPropertyName("account_name")]
+        public string AccountName { get; set; }
+
+        [JsonPropertyName("amount")]
+        public long Amount { get; set; }
+
+        [JsonPropertyName("narration")]
+        public string Narration { get; set; }
+
+        [JsonPropertyName("status")]
+        public string Status { get; set; }
+
+        [JsonPropertyName("failure_reason")]
+        public string FailureReason { get; set; }
+
+        [JsonPropertyName("processed_at")]
+        public DateTime? ProcessedAt { get; set; }
+
+        [JsonPropertyName("created_at")]
+        public DateTime? CreatedAt { get; set; }
+
+        [JsonPropertyName("updated_at")]
+        public DateTime? UpdatedAt { get; set; }
+    }
+
+    public class DistributionListResponse
+    {
+        [JsonPropertyName("distributions")]
+        public List<DistributionResponse> Distributions { get; set; }
+
+        [JsonPropertyName("meta")]
+        public DisbursePaginationMeta Meta { get; set; }
+    }
+
+    public class DistributionListQueryOptions
+    {
+        [JsonPropertyName("page")]
+        public int? Page { get; set; }
+
+        [JsonPropertyName("limit")]
+        public int? Limit { get; set; }
+
+        [JsonPropertyName("status")]
+        public string Status { get; set; }
+    }
+
+    public class DisbursePaginationMeta
+    {
+        [JsonPropertyName("total")]
+        public long Total { get; set; }
+
+        [JsonPropertyName("page")]
+        public long Page { get; set; }
+
+        [JsonPropertyName("previous")]
+        public string Previous { get; set; }
+
+        [JsonPropertyName("next")]
+        public string Next { get; set; }
+    }
+
+    // ============ Constants ============
+
+    public class DisbursementTypeConstants
+    {
+        public const string Instant = "instant";
+        public const string Scheduled = "scheduled";
+    }
+
+    public class DisbursementSourceConstants
+    {
+        public const string Mandate = "mandate";
+    }
+
+    public class TransitionActionConstants
+    {
+        public const string Trigger = "trigger";
+        public const string Cancel = "cancel";
+    }
+}

--- a/Readme.md
+++ b/Readme.md
@@ -10,6 +10,7 @@ Mono.Core is a .NET library that provides services and utilities for Mono accoun
 - [IMonoAuthorization](#imonoauthorization)
 - [IMonoCustomers](#imonocustomers)
 - [IMonoDirectPay](#imonodirectpay)
+- [IMonoDisburse](#imonodisburse)
 - [IMonoLookUp](#imonolookup)
 - [IMonoMiscellaneous](#imonomiscellaneous)
 
@@ -201,6 +202,56 @@ This interface provides methods for managing direct pay in Mono.
 - `VerifyPayment` This method is use to Verify the payment using the reference passed when initiating payment.
 - `GetTransactions` This method is use to retrive payment transactions of a specific account.
 
+### IMonoDisburse
+
+This interface wraps the Mono Disburse API (`/v3/payments/disburse/...`). Use it to pay out funds — salary, vendor settlements, marketplace splits, cashback — to one or many recipients from a registered source account.
+
+The flow is: register a source account → create a disbursement batch with one or more distributions → trigger or schedule it.
+
+**Source accounts:**
+- `CreateSourceAccount` Registers a funding account.
+- `UpdateSourceAccount` Updates a registered source account.
+- `FetchAllSourceAccounts` Lists registered source accounts.
+- `FetchSourceAccount` Fetches a single source account by id.
+
+**Disbursements (batches):**
+- `CreateDisbursement` Creates a batch. Set `type` to `instant` or `scheduled`.
+- `CreateInstantDisbursement` / `CreateScheduledDisbursement` Convenience wrappers that set the `type` for you.
+- `TransitionDisbursement` Changes a scheduled batch's state — `trigger` to execute now, `cancel` to stop it.
+- `FetchAllDisbursements` Lists batches.
+- `FetchDisbursement` Fetches a single batch.
+
+**Distributions (recipients within a batch):**
+- `AddDistributionsToBatch` Adds one or more recipients to an existing batch.
+- `UpdateDistributionInBatch` Edits a recipient (all fields optional).
+- `DeleteDistributionInBatch` Removes a recipient from a batch.
+- `FetchAllDistributionsInBatch` Lists recipients in a batch.
+- `FetchSingleDistribution` Fetches a single recipient by id.
+
+```csharp
+using Mono.Core.Disburse;
+
+var disbursement = await _disburse.CreateInstantDisbursement(new CreateDisbursementModel
+{
+    Reference = "payroll-2026-05",
+    Source = DisbursementSourceConstants.Mandate,
+    Account = sourceAccountId,
+    TotalAmount = 250_000_00,
+    Description = "May payroll",
+    Distribution = new List<DistributionModel>
+    {
+        new DistributionModel
+        {
+            Reference = "payroll-ada",
+            RecipientEmail = "ada@example.com",
+            Account = new DisbursementRecipientAccount { AccountNumber = "0123456789", BankCode = "044" },
+            Amount = 250_000_00,
+            Narration = "May salary",
+        },
+    },
+});
+```
+
 ### IMonoLookUp
 
 This interface provides methods for looking up information in Mono.
@@ -231,6 +282,41 @@ This interface provides miscellaneous methods for managing Mono.
 - `GetCacLookup` This method to retieve cac lookup information.
 - `GetCacCompany` This method is use to retrieve shareholder information of a company.
 - `UnLinkAccount` This method provide you with the option to unlink their financial account(s).
+
+## Changes in 1.3.0 (May 2026)
+
+Adds the Mono Disburse API surface (added by Mono in September 2025). Disburse handles outbound payments — salary, vendor settlements, marketplace splits, cashback — to one or many recipients from a registered source account.
+
+**New `IMonoDisburse` interface — 13 endpoints under `/v3/payments/disburse/...`:**
+
+*Source accounts:*
+- `CreateSourceAccount` (POST `/payments/disburse/source-accounts`)
+- `UpdateSourceAccount` (PUT `/payments/disburse/source-accounts`)
+- `FetchAllSourceAccounts` (GET `/payments/disburse/source-accounts`)
+- `FetchSourceAccount` (GET `/payments/disburse/source-accounts/{id}`)
+
+*Disbursements (batches):*
+- `CreateDisbursement` (POST `/payments/disburse/disbursements`)
+- `CreateInstantDisbursement` / `CreateScheduledDisbursement` (convenience wrappers)
+- `TransitionDisbursement` (POST `/payments/disburse/disbursements/{id}/transition`)
+- `FetchAllDisbursements` (GET `/payments/disburse/disbursements`)
+- `FetchDisbursement` (GET `/payments/disburse/disbursements/{id}`)
+
+*Distributions:*
+- `AddDistributionsToBatch` (POST `/payments/disburse/disbursements/{id}/distributions`)
+- `UpdateDistributionInBatch` (PATCH `/payments/disburse/disbursements/{id}/distributions/{distId}`)
+- `DeleteDistributionInBatch` (DELETE `/payments/disburse/disbursements/{id}/distributions/{distId}`)
+- `FetchAllDistributionsInBatch` (GET `/payments/disburse/disbursements/{id}/distributions`)
+- `FetchSingleDistribution` (GET `/payments/disburse/disbursements/{id}/distributions/{distId}`)
+
+**Registration:**
+- `AddMono(...)` now also wires up `IMonoDisburse`
+- Standalone `AddMonoDisburse(...)` extension available
+
+**Constants:**
+- `DisbursementTypeConstants` (`instant` / `scheduled`)
+- `DisbursementSourceConstants` (`mandate`)
+- `TransitionActionConstants` (`trigger` / `cancel`)
 
 ## Changes in 1.2.0 (May 2026)
 


### PR DESCRIPTION
## Summary

Adds the Mono **Disburse API** (released by Mono September 2025). Disburse handles outbound payments — salary, vendor settlements, marketplace splits, cashback — to one or many recipients from a registered source account.

The flow: **register a source account → create a disbursement batch with one or more distributions → trigger or schedule it.**

## New surface — `IMonoDisburse` (13 endpoints, all v3)

### Source accounts
| Method | Endpoint |
|---|---|
| `CreateSourceAccount` | POST `/payments/disburse/source-accounts` |
| `UpdateSourceAccount` | PUT `/payments/disburse/source-accounts` |
| `FetchAllSourceAccounts` | GET `/payments/disburse/source-accounts` |
| `FetchSourceAccount` | GET `/payments/disburse/source-accounts/{id}` |

### Disbursements (batches)
| Method | Endpoint |
|---|---|
| `CreateDisbursement` | POST `/payments/disburse/disbursements` (set `type=instant`\|`scheduled`) |
| `CreateInstantDisbursement` | wrapper — sets `type=instant` for you |
| `CreateScheduledDisbursement` | wrapper — sets `type=scheduled` |
| `TransitionDisbursement` | POST `/payments/disburse/disbursements/{id}/transition` (`action=trigger`\|`cancel`) |
| `FetchAllDisbursements` | GET `/payments/disburse/disbursements` |
| `FetchDisbursement` | GET `/payments/disburse/disbursements/{id}` |

### Distributions (recipients within a batch)
| Method | Endpoint |
|---|---|
| `AddDistributionsToBatch` | POST `/payments/disburse/disbursements/{id}/distributions` |
| `UpdateDistributionInBatch` | PATCH `/payments/disburse/disbursements/{id}/distributions/{distId}` |
| `DeleteDistributionInBatch` | DELETE `/payments/disburse/disbursements/{id}/distributions/{distId}` |
| `FetchAllDistributionsInBatch` | GET `/payments/disburse/disbursements/{id}/distributions` |
| `FetchSingleDistribution` | GET `/payments/disburse/disbursements/{id}/distributions/{distId}` |

## Implementation notes

- All endpoints route through `IRefitClientBuilder<IDisburseService>.BuildV3()` since Disburse is v3-only. The Refit attribute paths omit the version prefix because `RefitClientBuilder.BuildV3()` rewrites `BaseUrl` from `/v2/` to `/v3/` at call time.
- The same `POST /payments/disburse/disbursements` endpoint handles both instant and scheduled disbursements — only the body differs. `CreateInstantDisbursement` / `CreateScheduledDisbursement` are sugar that set `type` for you so callers don't forget.
- For scheduled disbursements, set `ScheduledDate` (ISO-8601). Mono's docs are vague on the exact field name (no schedule-specific fields appeared in the documented example); `scheduled_date` matches Mono's wider naming convention. Worth confirming in sandbox.

## DI

- `AddMono(...)` now also registers `IMonoDisburse`
- Standalone `AddMonoDisburse(...)` follows the existing per-service registration pattern

## Constants

- `DisbursementTypeConstants` — `instant` / `scheduled`
- `DisbursementSourceConstants` — `mandate` (only documented funding source today)
- `TransitionActionConstants` — `trigger` / `cancel`

## Code layout

```
Mono.Core/Services/Disburse/
├── Abstractions/
│   ├── IDisburseService.cs   (Refit interface — v3)
│   └── IMonoDisburse.cs       (high-level interface)
├── Models/
│   └── DisburseModels.cs       (requests, responses, constants)
└── DisburseService.cs           (high-level implementation)
```

## Compat

- Pure additive — no existing interface or method changed
- Package version: 1.2.0 → 1.3.0 (minor bump)

## Test plan

- [x] `dotnet build` — succeeds, no new warnings
- [x] All Refit attributes use the existing `IApiResponse<MonoStandardResponse<T>>` shape so `HandleResponse()` works uniformly
- [ ] Sandbox smoke-test before NuGet publish:
  - [ ] Create a source account, then list + fetch
  - [ ] Create an instant disbursement with a single recipient; verify `total_amount` and per-distribution `amount` semantics match
  - [ ] Create a scheduled disbursement, transition with `cancel`, then again with `trigger`
  - [ ] Add a distribution to a batch, update its amount, list, delete
- [ ] Verify list/distribution response wrapper field names — Mono's public docs don't expose full 200 schemas. Modeled list responses as `{ source_accounts/disbursements/distributions: [], meta: {...} }` consistent with other Mono list endpoints. Adjust if sandbox returns different keys.
- [ ] Confirm the scheduled-disbursement date field is `scheduled_date` (not `schedule`, `scheduled_for`, `execute_at`, etc.) — Mono's docs were silent on it.

## Follow-up PRs still queued

- **Watchlist Screening** (March 2026)
- **Prove** identity verification
- **Connect additions**: real-time `account-balance`, Account Match, Get-All-Accounts at the Account layer
- **NIN poll-job** endpoint + `output=pdf`
- **CAC**: PSC, Profile, Status-Report (replaces the deprecated change-of-name / previous-address)
- **DirectPay**: Refund, Payout (by status), Payout Transactions
- **Webhook hardening**: `mono-webhook-secret` signature verification, new event types (Disburse events, mandate `debit.successful`, income, creditworthiness), `event_id` + `timestamp` on all payloads

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce a new Disburse service surface for handling outbound payment batches and their recipients via Mono’s v3 Disburse API.

New Features:
- Add IMonoDisburse high-level interface and Refit-backed IDisburseService for managing source accounts, disbursements, and distributions.
- Provide comprehensive Disburse models for source accounts, disbursement batches, and per-recipient distributions, including pagination metadata and related constants for types, sources, and transition actions.
- Expose new DI registration helpers so Disburse can be wired via AddMono(...) or standalone AddMonoDisburse(...).
- Document the new Disburse capability in the README with an interface overview, usage example, and a 1.3.0 change log entry.