### PR TITLE
Add Mono Watchlist Screening API surface (v1.4.0)

### DIFF
--- a/Mono.Core/Extensions/IServiceCollectionExtension.cs
+++ b/Mono.Core/Extensions/IServiceCollectionExtension.cs
@@ -7,6 +7,7 @@ using Mono.Core.Customers;
 using Mono.Core.DirectPay;
 using Mono.Core.LookUp;
 using Mono.Core.Miscellaneous; // Add this using directive
+using Mono.Core.Watchlist;
 
 namespace Mono.Core
 {
@@ -22,6 +23,7 @@ namespace Mono.Core
             services.AddTransient<IMonoMiscellaneous, MiscellaneousService>(); // Add this line
             services.AddTransient<IMonoLookUp, LookUpService>();
             services.AddTransient<IMonoCustomers, CustomerService>();
+            services.AddTransient<IMonoWatchlist, WatchlistService>();
             return services;
         }
 
@@ -70,6 +72,14 @@ namespace Mono.Core
             services.Configure(options);
             services.AddTransient(typeof(IRefitClientBuilder<>), typeof(RefitClientBuilder<>));
             services.AddTransient<IMonoCustomers, CustomerService>();
+            return services;
+        }
+
+        public static IServiceCollection AddMonoWatchlist(this IServiceCollection services, Action<MonoInitializationOptions> options)
+        {
+            services.Configure(options);
+            services.AddTransient(typeof(IRefitClientBuilder<>), typeof(RefitClientBuilder<>));
+            services.AddTransient<IMonoWatchlist, WatchlistService>();
             return services;
         }
 

--- a/Mono.Core/Mono.Core.csproj
+++ b/Mono.Core/Mono.Core.csproj
@@ -5,7 +5,7 @@
 			Mono.Core
 		</PackageId>
 		<Version>
-			1.2.0
+			1.4.0
 		</Version>
 		<Authors>
 			Adelowomi

--- a/Mono.Core/Services/Watchlist/Abstractions/IMonoWatchlist.cs
+++ b/Mono.Core/Services/Watchlist/Abstractions/IMonoWatchlist.cs
@@ -1,0 +1,68 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Mono.Core.Watchlist
+{
+    public interface IMonoWatchlist
+    {
+        /// <summary>
+        /// Submits an individual for watchlist screening (sanctions, PEP, adverse media).
+        /// </summary>
+        Task<MonoStandardResponse<ScreeningResponse>> SubmitIndividualScreening(
+            SubmitIndividualScreeningModel model,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Submits a business / entity for watchlist screening.
+        /// </summary>
+        Task<MonoStandardResponse<ScreeningResponse>> SubmitEntityScreening(
+            SubmitEntityScreeningModel model,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Submits multiple individuals and/or entities in a single call. Each entry's
+        /// <see cref="WatchlistScreeningSubject.Type"/> picks which fields apply.
+        /// </summary>
+        Task<MonoStandardResponse<BatchScreeningResponse>> SubmitBatchScreening(
+            BatchScreeningModel model,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Retrieves a screening's current state (status, matches, risk score, etc.).
+        /// </summary>
+        Task<MonoStandardResponse<ScreeningResponse>> GetScreeningResult(
+            string id,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Retrieves the lifecycle audit log for a screening.
+        /// </summary>
+        Task<MonoStandardResponse<AuditLogResponse>> GetAuditLog(
+            string id,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Downloads the screening's PDF compliance report. On success returns the
+        /// raw PDF bytes in <see cref="MonoStandardResponse{T}.Data"/>; on failure
+        /// the standard JSON error fields are populated.
+        /// </summary>
+        Task<MonoStandardResponse<byte[]>> GetScreeningReport(
+            string id,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Enrolls a subject in ongoing monitoring — Mono will continuously re-screen
+        /// and emit webhook events when new matches appear.
+        /// </summary>
+        Task<MonoStandardResponse<MonitoringResponse>> StartMonitoring(
+            StartMonitoringModel model,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Cancels ongoing monitoring for the given subject id.
+        /// </summary>
+        Task<MonoStandardResponse<dynamic>> StopMonitoring(
+            string id,
+            CancellationToken cancellationToken = default);
+    }
+}

--- a/Mono.Core/Services/Watchlist/Abstractions/IWatchlistService.cs
+++ b/Mono.Core/Services/Watchlist/Abstractions/IWatchlistService.cs
@@ -1,0 +1,62 @@
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Refit;
+
+namespace Mono.Core.Watchlist
+{
+    // Refit interface for the Mono Watchlist Screening API (v3).
+    // Uses BuildV3() so the base URL is rewritten from /v2/ to /v3/ before
+    // every call; paths here omit the version prefix.
+    public interface IWatchlistService
+    {
+        // -------- Submit / batch screening --------
+
+        [Post("/lookup/watchlist")]
+        Task<IApiResponse<MonoStandardResponse<ScreeningResponse>>> SubmitIndividualScreening(
+            [Body] SubmitIndividualScreeningModel model,
+            CancellationToken cancellationToken = default);
+
+        [Post("/lookup/watchlist")]
+        Task<IApiResponse<MonoStandardResponse<ScreeningResponse>>> SubmitEntityScreening(
+            [Body] SubmitEntityScreeningModel model,
+            CancellationToken cancellationToken = default);
+
+        [Post("/lookup/watchlist/batch")]
+        Task<IApiResponse<MonoStandardResponse<BatchScreeningResponse>>> SubmitBatchScreening(
+            [Body] BatchScreeningModel model,
+            CancellationToken cancellationToken = default);
+
+        // -------- Fetch screening data --------
+
+        [Get("/lookup/watchlist/{id}")]
+        Task<IApiResponse<MonoStandardResponse<ScreeningResponse>>> GetScreeningResult(
+            string id,
+            CancellationToken cancellationToken = default);
+
+        [Get("/lookup/watchlist/{id}/audit-log")]
+        Task<IApiResponse<MonoStandardResponse<AuditLogResponse>>> GetAuditLog(
+            string id,
+            CancellationToken cancellationToken = default);
+
+        // PDF binary download — bypasses MonoStandardResponse<T> wrapping.
+        // The high-level facade reads the bytes (or parses the error JSON
+        // on a non-2xx response) and wraps the result.
+        [Get("/lookup/watchlist/{id}/report")]
+        Task<HttpResponseMessage> GetScreeningReport(
+            string id,
+            CancellationToken cancellationToken = default);
+
+        // -------- Ongoing monitoring --------
+
+        [Post("/lookup/watchlist/monitor")]
+        Task<IApiResponse<MonoStandardResponse<MonitoringResponse>>> StartMonitoring(
+            [Body] StartMonitoringModel model,
+            CancellationToken cancellationToken = default);
+
+        [Delete("/lookup/watchlist/monitor/{id}")]
+        Task<IApiResponse<MonoStandardResponse<dynamic>>> StopMonitoring(
+            string id,
+            CancellationToken cancellationToken = default);
+    }
+}

--- a/Mono.Core/Services/Watchlist/Models/WatchlistModels.cs
+++ b/Mono.Core/Services/Watchlist/Models/WatchlistModels.cs
@@ -1,0 +1,287 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
+
+namespace Mono.Core.Watchlist
+{
+    // ============ Submit screening ============
+
+    public class SubmitIndividualScreeningModel
+    {
+        [Required]
+        [JsonPropertyName("type")]
+        public string Type { get; set; } = WatchlistSubjectTypeConstants.Individual;
+
+        [Required]
+        [JsonPropertyName("name")]
+        public string Name { get; set; }
+
+        [JsonPropertyName("date_of_birth")]
+        public string DateOfBirth { get; set; }
+
+        [JsonPropertyName("gender")]
+        public string Gender { get; set; }
+
+        [JsonPropertyName("bvn")]
+        public string Bvn { get; set; }
+
+        [Required]
+        [JsonPropertyName("country")]
+        public string Country { get; set; }
+    }
+
+    public class SubmitEntityScreeningModel
+    {
+        [Required]
+        [JsonPropertyName("type")]
+        public string Type { get; set; } = WatchlistSubjectTypeConstants.Entity;
+
+        [Required]
+        [JsonPropertyName("name")]
+        public string Name { get; set; }
+
+        [JsonPropertyName("address")]
+        public string Address { get; set; }
+
+        [Required]
+        [JsonPropertyName("country")]
+        public string Country { get; set; }
+    }
+
+    /// <summary>
+    /// Flat shape used inside batch requests. Populate the fields that match
+    /// the <see cref="Type"/> ("individual" or "entity") — irrelevant fields can
+    /// remain null and will be omitted from the serialized JSON if the calling
+    /// serializer skips nulls, or sent as nulls otherwise.
+    /// </summary>
+    public class WatchlistScreeningSubject
+    {
+        [Required]
+        [JsonPropertyName("type")]
+        public string Type { get; set; }
+
+        [Required]
+        [JsonPropertyName("name")]
+        public string Name { get; set; }
+
+        [Required]
+        [JsonPropertyName("country")]
+        public string Country { get; set; }
+
+        // Individual-only
+        [JsonPropertyName("date_of_birth")]
+        public string DateOfBirth { get; set; }
+
+        [JsonPropertyName("gender")]
+        public string Gender { get; set; }
+
+        [JsonPropertyName("bvn")]
+        public string Bvn { get; set; }
+
+        // Entity-only
+        [JsonPropertyName("address")]
+        public string Address { get; set; }
+    }
+
+    public class BatchScreeningModel
+    {
+        [Required]
+        [JsonPropertyName("entries")]
+        public List<WatchlistScreeningSubject> Entries { get; set; }
+    }
+
+    // ============ Monitoring ============
+
+    public class StartMonitoringModel
+    {
+        [Required]
+        [JsonPropertyName("type")]
+        public string Type { get; set; }
+
+        [Required]
+        [JsonPropertyName("name")]
+        public string Name { get; set; }
+
+        [Required]
+        [JsonPropertyName("country")]
+        public string Country { get; set; }
+
+        [JsonPropertyName("date_of_birth")]
+        public string DateOfBirth { get; set; }
+
+        [JsonPropertyName("gender")]
+        public string Gender { get; set; }
+
+        [JsonPropertyName("bvn")]
+        public string Bvn { get; set; }
+
+        [JsonPropertyName("address")]
+        public string Address { get; set; }
+    }
+
+    // ============ Responses ============
+
+    public class WatchlistMatchSource
+    {
+        [JsonPropertyName("name")]
+        public string Name { get; set; }
+
+        [JsonPropertyName("category")]
+        public string Category { get; set; }
+
+        [JsonPropertyName("country")]
+        public string Country { get; set; }
+    }
+
+    public class WatchlistMatch
+    {
+        [JsonPropertyName("id")]
+        public string Id { get; set; }
+
+        [JsonPropertyName("name")]
+        public string Name { get; set; }
+
+        [JsonPropertyName("match_score")]
+        public double? MatchScore { get; set; }
+
+        [JsonPropertyName("match_level")]
+        public string MatchLevel { get; set; }
+
+        [JsonPropertyName("categories")]
+        public List<string> Categories { get; set; }
+
+        [JsonPropertyName("aliases")]
+        public List<string> Aliases { get; set; }
+
+        [JsonPropertyName("source")]
+        public WatchlistMatchSource Source { get; set; }
+
+        [JsonPropertyName("listed_on")]
+        public DateTime? ListedOn { get; set; }
+    }
+
+    public class ScreeningSubjectSummary
+    {
+        [JsonPropertyName("type")]
+        public string Type { get; set; }
+
+        [JsonPropertyName("name")]
+        public string Name { get; set; }
+
+        [JsonPropertyName("country")]
+        public string Country { get; set; }
+
+        [JsonPropertyName("date_of_birth")]
+        public string DateOfBirth { get; set; }
+
+        [JsonPropertyName("bvn")]
+        public string Bvn { get; set; }
+
+        [JsonPropertyName("address")]
+        public string Address { get; set; }
+    }
+
+    public class ScreeningResponse
+    {
+        [JsonPropertyName("id")]
+        public string Id { get; set; }
+
+        [JsonPropertyName("status")]
+        public string Status { get; set; }
+
+        [JsonPropertyName("subject")]
+        public ScreeningSubjectSummary Subject { get; set; }
+
+        [JsonPropertyName("risk_score")]
+        public double? RiskScore { get; set; }
+
+        [JsonPropertyName("risk_level")]
+        public string RiskLevel { get; set; }
+
+        [JsonPropertyName("matches")]
+        public List<WatchlistMatch> Matches { get; set; }
+
+        [JsonPropertyName("monitoring")]
+        public bool? Monitoring { get; set; }
+
+        [JsonPropertyName("created_at")]
+        public DateTime? CreatedAt { get; set; }
+
+        [JsonPropertyName("updated_at")]
+        public DateTime? UpdatedAt { get; set; }
+    }
+
+    public class BatchScreeningResponse
+    {
+        [JsonPropertyName("results")]
+        public List<ScreeningResponse> Results { get; set; }
+    }
+
+    public class AuditLogEntry
+    {
+        [JsonPropertyName("id")]
+        public string Id { get; set; }
+
+        [JsonPropertyName("event")]
+        public string Event { get; set; }
+
+        [JsonPropertyName("actor")]
+        public string Actor { get; set; }
+
+        [JsonPropertyName("details")]
+        public object Details { get; set; }
+
+        [JsonPropertyName("created_at")]
+        public DateTime? CreatedAt { get; set; }
+    }
+
+    public class AuditLogResponse
+    {
+        [JsonPropertyName("entries")]
+        public List<AuditLogEntry> Entries { get; set; }
+    }
+
+    public class MonitoringResponse
+    {
+        [JsonPropertyName("id")]
+        public string Id { get; set; }
+
+        [JsonPropertyName("subject")]
+        public ScreeningSubjectSummary Subject { get; set; }
+
+        [JsonPropertyName("status")]
+        public string Status { get; set; }
+
+        [JsonPropertyName("monitoring")]
+        public bool? Monitoring { get; set; }
+
+        [JsonPropertyName("created_at")]
+        public DateTime? CreatedAt { get; set; }
+
+        [JsonPropertyName("updated_at")]
+        public DateTime? UpdatedAt { get; set; }
+    }
+
+    // ============ Constants ============
+
+    public class WatchlistSubjectTypeConstants
+    {
+        public const string Individual = "individual";
+        public const string Entity = "entity";
+    }
+
+    public class ScreeningStatusConstants
+    {
+        public const string Processing = "processing";
+        public const string Completed = "completed";
+        public const string Failed = "failed";
+    }
+
+    public class RiskLevelConstants
+    {
+        public const string Low = "low";
+        public const string Medium = "medium";
+        public const string High = "high";
+    }
+}

--- a/Mono.Core/Services/Watchlist/WatchlistService.cs
+++ b/Mono.Core/Services/Watchlist/WatchlistService.cs
@@ -1,0 +1,110 @@
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Mono.Core.Watchlist
+{
+    public class WatchlistService : IMonoWatchlist
+    {
+        private readonly IWatchlistService _watchlistService;
+
+        public WatchlistService(IRefitClientBuilder<IWatchlistService> watchlistService)
+        {
+            // Watchlist Screening is v3-only.
+            _watchlistService = watchlistService.BuildV3(ServiceTypes.Lookup);
+        }
+
+        public async Task<MonoStandardResponse<ScreeningResponse>> SubmitIndividualScreening(
+            SubmitIndividualScreeningModel model,
+            CancellationToken cancellationToken = default)
+        {
+            var response = await _watchlistService.SubmitIndividualScreening(model, cancellationToken);
+            return response.HandleResponse();
+        }
+
+        public async Task<MonoStandardResponse<ScreeningResponse>> SubmitEntityScreening(
+            SubmitEntityScreeningModel model,
+            CancellationToken cancellationToken = default)
+        {
+            var response = await _watchlistService.SubmitEntityScreening(model, cancellationToken);
+            return response.HandleResponse();
+        }
+
+        public async Task<MonoStandardResponse<BatchScreeningResponse>> SubmitBatchScreening(
+            BatchScreeningModel model,
+            CancellationToken cancellationToken = default)
+        {
+            var response = await _watchlistService.SubmitBatchScreening(model, cancellationToken);
+            return response.HandleResponse();
+        }
+
+        public async Task<MonoStandardResponse<ScreeningResponse>> GetScreeningResult(
+            string id,
+            CancellationToken cancellationToken = default)
+        {
+            var response = await _watchlistService.GetScreeningResult(id, cancellationToken);
+            return response.HandleResponse();
+        }
+
+        public async Task<MonoStandardResponse<AuditLogResponse>> GetAuditLog(
+            string id,
+            CancellationToken cancellationToken = default)
+        {
+            var response = await _watchlistService.GetAuditLog(id, cancellationToken);
+            return response.HandleResponse();
+        }
+
+        public async Task<MonoStandardResponse<byte[]>> GetScreeningReport(
+            string id,
+            CancellationToken cancellationToken = default)
+        {
+            using (var response = await _watchlistService.GetScreeningReport(id, cancellationToken))
+            {
+                if (response.IsSuccessStatusCode)
+                {
+                    var bytes = await response.Content.ReadAsByteArrayAsync().ConfigureAwait(false);
+                    var ok = MonoStandardResponse<byte[]>.Ok(bytes);
+                    ok.Status = ((int)response.StatusCode).ToString();
+                    return ok;
+                }
+
+                var errorJson = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+                try
+                {
+                    var parsed = JsonSerializer.Deserialize<MonoStandardResponse<byte[]>>(errorJson);
+                    if (parsed != null)
+                    {
+                        parsed.Success = false;
+                        return parsed;
+                    }
+                }
+                catch (JsonException)
+                {
+                    // Fall through to a generic error wrapper.
+                }
+
+                return MonoStandardResponse<byte[]>.Error(
+                    string.IsNullOrEmpty(errorJson)
+                        ? $"PDF report request failed with status {(int)response.StatusCode}"
+                        : errorJson);
+            }
+        }
+
+        public async Task<MonoStandardResponse<MonitoringResponse>> StartMonitoring(
+            StartMonitoringModel model,
+            CancellationToken cancellationToken = default)
+        {
+            var response = await _watchlistService.StartMonitoring(model, cancellationToken);
+            return response.HandleResponse();
+        }
+
+        public async Task<MonoStandardResponse<dynamic>> StopMonitoring(
+            string id,
+            CancellationToken cancellationToken = default)
+        {
+            var response = await _watchlistService.StopMonitoring(id, cancellationToken);
+            return response.HandleResponse();
+        }
+    }
+}

--- a/Readme.md
+++ b/Readme.md
@@ -12,6 +12,7 @@ Mono.Core is a .NET library that provides services and utilities for Mono accoun
 - [IMonoDirectPay](#imonodirectpay)
 - [IMonoLookUp](#imonolookup)
 - [IMonoMiscellaneous](#imonomiscellaneous)
+- [IMonoWatchlist](#imonowatchlist)
 
 ## Configuration
 
@@ -223,6 +224,38 @@ This interface provides methods for looking up information in Mono.
 - `GetCreditHistory` This method enables you to retrieve a user's credit history.
 - `GetMashUp` This method allows you to verify the NIN, BVN and date of birth of your user in one API call for KYC.
 
+### IMonoWatchlist
+
+This interface wraps the Mono Watchlist Screening API (`/v3/lookup/watchlist/...`) — sanctions, PEP and adverse-media screening with risk scores, batch screening, an audit log per screening, PDF compliance reports, and ongoing monitoring.
+
+- `SubmitIndividualScreening` Screens a single individual.
+- `SubmitEntityScreening` Screens a single business / entity.
+- `SubmitBatchScreening` Screens multiple subjects in one call.
+- `GetScreeningResult` Polls a screening's status, matches and risk score.
+- `GetAuditLog` Lifecycle events for a screening.
+- `GetScreeningReport` Downloads the PDF compliance report. Returns raw bytes in `Data`.
+- `StartMonitoring` Enrolls a subject in continuous monitoring.
+- `StopMonitoring` Cancels ongoing monitoring.
+
+```csharp
+using Mono.Core.Watchlist;
+
+var screening = await _watchlist.SubmitIndividualScreening(new SubmitIndividualScreeningModel
+{
+    Name = "Ada Lovelace",
+    DateOfBirth = "1815-12-10",
+    Gender = "female",
+    Bvn = "12345678901",
+    Country = "NG",
+});
+
+if (screening.Data.RiskLevel == RiskLevelConstants.High)
+{
+    var report = await _watchlist.GetScreeningReport(screening.Data.Id);
+    await File.WriteAllBytesAsync($"screening-{screening.Data.Id}.pdf", report.Data);
+}
+```
+
 ### IMonoMiscellaneous
 
 This interface provides miscellaneous methods for managing Mono.
@@ -231,6 +264,31 @@ This interface provides miscellaneous methods for managing Mono.
 - `GetCacLookup` This method to retieve cac lookup information.
 - `GetCacCompany` This method is use to retrieve shareholder information of a company.
 - `UnLinkAccount` This method provide you with the option to unlink their financial account(s).
+
+## Changes in 1.4.0 (May 2026)
+
+Adds the Mono Watchlist Screening API surface (released by Mono in March 2026). Watchlist Screening matches subjects against sanctions, PEP and adverse-media lists, returns a risk score, and can run ongoing monitoring.
+
+> Note: assumes Mono Disburse (v1.3.0) lands first. If Watchlist merges first this bumps to 1.3.0 instead.
+
+**New `IMonoWatchlist` interface — 7 endpoints under `/v3/lookup/watchlist/...`:**
+- `SubmitIndividualScreening` (POST `/lookup/watchlist`, `type=individual`)
+- `SubmitEntityScreening` (POST `/lookup/watchlist`, `type=entity`)
+- `SubmitBatchScreening` (POST `/lookup/watchlist/batch`)
+- `GetScreeningResult` (GET `/lookup/watchlist/{id}`)
+- `GetAuditLog` (GET `/lookup/watchlist/{id}/audit-log`)
+- `GetScreeningReport` (GET `/lookup/watchlist/{id}/report` — binary PDF, returned as `byte[]`)
+- `StartMonitoring` (POST `/lookup/watchlist/monitor`)
+- `StopMonitoring` (DELETE `/lookup/watchlist/monitor/{id}`)
+
+**Registration:**
+- `AddMono(...)` now also wires up `IMonoWatchlist`
+- Standalone `AddMonoWatchlist(...)` extension available
+
+**Constants:**
+- `WatchlistSubjectTypeConstants` (`individual` / `entity`)
+- `ScreeningStatusConstants` (`processing` / `completed` / `failed`)
+- `RiskLevelConstants` (`low` / `medium` / `high`)
 
 ## Changes in 1.2.0 (May 2026)
 


### PR DESCRIPTION
## Summary

Adds the Mono **Watchlist Screening API** (released March 2026). Watchlist Screening matches subjects against sanctions lists, PEP databases and adverse-media records, returns a risk score and match details, and can run ongoing monitoring with webhook callbacks.

This is a compliance/KYC building block — typically used to gate customer onboarding, payouts, or high-value transactions.

## New surface — `IMonoWatchlist` (7 endpoints, all v3)

| Method | Endpoint | Notes |
|---|---|---|
| `SubmitIndividualScreening` | POST `/lookup/watchlist` | `type=individual`, fields: name, dob, gender, bvn, country |
| `SubmitEntityScreening` | POST `/lookup/watchlist` | `type=entity`, fields: name, address, country |
| `SubmitBatchScreening` | POST `/lookup/watchlist/batch` | `entries` array, mixed individuals + entities |
| `GetScreeningResult` | GET `/lookup/watchlist/{id}` | Returns `status`, `matches[]`, `risk_score`, `risk_level` |
| `GetAuditLog` | GET `/lookup/watchlist/{id}/audit-log` | Lifecycle events |
| `GetScreeningReport` | GET `/lookup/watchlist/{id}/report` | **Binary PDF** — returned as `byte[]` |
| `StartMonitoring` | POST `/lookup/watchlist/monitor` | Continuous re-screening |
| `StopMonitoring` | DELETE `/lookup/watchlist/monitor/{id}` | Cancels monitoring |

## Special handling: PDF binary report

The compliance report endpoint returns raw PDF bytes, not JSON. To keep the rest of the library's `MonoStandardResponse<T>` shape consistent for consumers:

- The Refit method returns `Task<HttpResponseMessage>` (bypasses Refit's content deserializer)
- The high-level `GetScreeningReport` method:
  - On 2xx: reads bytes via `ReadAsByteArrayAsync()`, returns `MonoStandardResponse<byte[]>.Ok(bytes)`
  - On non-2xx: reads the error body as JSON and parses it into `MonoStandardResponse<byte[]>` to surface Mono's standard error fields
  - On unparseable error: returns a generic `MonoStandardResponse<byte[]>.Error(...)` with the raw status

This way consumers get `response.Data` as `byte[]` on success and the usual `Success`/`Message`/`MonoErrors` fields on failure.

## DI

- `AddMono(...)` now also registers `IMonoWatchlist`
- Standalone `AddMonoWatchlist(...)` follows the existing per-service registration pattern
- Uses the lookup secret key path (`ServiceTypes.Lookup`) since the endpoint lives under `/lookup/`

## Constants

- `WatchlistSubjectTypeConstants` — `individual` / `entity`
- `ScreeningStatusConstants` — `processing` / `completed` / `failed`
- `RiskLevelConstants` — `low` / `medium` / `high`

## Version note

PR is branched off `master` (currently at v1.2.0). Assumes the **Disburse PR (#6, v1.3.0)** merges first → Watchlist lands as **1.4.0**. If you merge Watchlist first, it should bump to 1.3.0 and Disburse #6 will need a rebase to 1.4.0. The Mono.Core.csproj and Readme version lines are the only conflict points; resolution is trivial.

## Code layout

```
Mono.Core/Services/Watchlist/
├── Abstractions/
│   ├── IWatchlistService.cs   (Refit interface — v3)
│   └── IMonoWatchlist.cs       (high-level interface)
├── Models/
│   └── WatchlistModels.cs       (requests, responses, constants)
└── WatchlistService.cs           (high-level implementation)
```

## Compat

- Pure additive — no existing interface or method changed
- Package version: 1.2.0 → 1.4.0 (assuming Disburse merges first)

## Test plan

- [x] `dotnet build` — succeeds with no new warnings
- [x] PDF binary handling: deliberately uses `HttpResponseMessage` to dodge the JSON deserializer; verified by build
- [ ] Sandbox smoke-test before NuGet publish:
  - [ ] Submit an individual + entity screening; poll status until `completed`
  - [ ] Verify `risk_score` / `risk_level` / `matches[]` shape against actual sandbox response
  - [ ] Submit a batch with mixed individual + entity entries
  - [ ] Download a PDF report; confirm bytes are a valid PDF (`%PDF-` header)
  - [ ] Start monitoring on a subject, stop monitoring, confirm webhook fires on a new match
- [ ] Field-name verification (Mono's public docs didn't show full 200 schemas):
  - [ ] `risk_score` vs `riskScore`
  - [ ] `match_level` vs `matchLevel`
  - [ ] `audit-log` response — `entries` array vs flat array
  - [ ] Batch response — `results` vs `screenings` vs flat array

## Follow-up PRs still queued

- **Prove** identity verification
- **Connect additions**: real-time `account-balance`, Account Match, Get-All-Accounts at the Account layer
- **NIN poll-job** endpoint + `output=pdf`
- **CAC**: PSC, Profile, Status-Report (replaces the deprecated change-of-name / previous-address)
- **DirectPay**: Refund, Payout (by status), Payout Transactions
- **Webhook hardening**: `mono-webhook-secret` signature verification, new event types (Watchlist match webhooks, Disburse, mandate `debit.successful`, income, creditworthiness), `event_id` + `timestamp` on payloads

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add a new watchlist screening service surface for Mono, including models, interfaces, and service wiring, and document it as part of the 1.4.0 release.

New Features:
- Introduce the IMonoWatchlist high-level interface and underlying Refit API client for Mono's v3 Watchlist Screening endpoints, including individual, entity, batch screening, audit log, PDF report download, and monitoring operations.

Enhancements:
- Wire the new IMonoWatchlist service into the existing DI registration via AddMono(...) and a dedicated AddMonoWatchlist(...) extension method.

Documentation:
- Document the IMonoWatchlist interface usage, including example code and API behavior, and add a 1.4.0 changelog section describing the new watchlist functionality and related constants.