### PR TITLE
Add Mono Prove API surface (v1.5.0)

### DIFF
--- a/Mono.Core/Extensions/IServiceCollectionExtension.cs
+++ b/Mono.Core/Extensions/IServiceCollectionExtension.cs
@@ -8,6 +8,7 @@ using Mono.Core.DirectPay;
 using Mono.Core.Disburse;
 using Mono.Core.LookUp;
 using Mono.Core.Miscellaneous; // Add this using directive
+using Mono.Core.Prove;
 using Mono.Core.Watchlist;
 
 namespace Mono.Core
@@ -26,6 +27,7 @@ namespace Mono.Core
             services.AddTransient<IMonoCustomers, CustomerService>();
             services.AddTransient<IMonoDisburse, DisburseService>();
             services.AddTransient<IMonoWatchlist, WatchlistService>();
+            services.AddTransient<IMonoProve, ProveService>();
             return services;
         }
 
@@ -90,6 +92,14 @@ namespace Mono.Core
             services.Configure(options);
             services.AddTransient(typeof(IRefitClientBuilder<>), typeof(RefitClientBuilder<>));
             services.AddTransient<IMonoWatchlist, WatchlistService>();
+            return services;
+        }
+
+        public static IServiceCollection AddMonoProve(this IServiceCollection services, Action<MonoInitializationOptions> options)
+        {
+            services.Configure(options);
+            services.AddTransient(typeof(IRefitClientBuilder<>), typeof(RefitClientBuilder<>));
+            services.AddTransient<IMonoProve, ProveService>();
             return services;
         }
 

--- a/Mono.Core/Models/UtilityModels/RefitClientBuilder.cs
+++ b/Mono.Core/Models/UtilityModels/RefitClientBuilder.cs
@@ -44,14 +44,41 @@ namespace Mono.Core
         // change the url of the client to replace "v2" with "v3"
         public T BuildV3(string serviceType = null)
         {
-            var secretKey = string.IsNullOrEmpty(serviceType) ? _options.SecretKey : 
-                            serviceType == "connect" ? _options.ConnectSecretKey ?? _options.SecretKey : 
-                            serviceType == "lookup" ? _options.LookupSecretKey ?? _options.SecretKey : 
+            var secretKey = string.IsNullOrEmpty(serviceType) ? _options.SecretKey :
+                            serviceType == "connect" ? _options.ConnectSecretKey ?? _options.SecretKey :
+                            serviceType == "lookup" ? _options.LookupSecretKey ?? _options.SecretKey :
                             throw new ArgumentException("Invalid service type");
 
             var client = new HttpClient(new HttpClientHandler())
             {
                 BaseAddress = new Uri(_options.BaseUrl.Replace("v2", "v3"))
+            };
+            client.DefaultRequestHeaders.Add("mono-sec-key", secretKey);
+            var buider = RequestBuilder.ForType<T>(new RefitSettings
+            {
+                ContentSerializer = new SystemTextJsonContentSerializer(
+                    new System.Text.Json.JsonSerializerOptions
+                    {
+                        PropertyNamingPolicy = System.Text.Json.JsonNamingPolicy.CamelCase,
+                        WriteIndented = true
+                    }
+                )
+            });
+            return RestService.For(client, buider);
+        }
+
+        // change the url of the client to replace "v2" with "v1" — used by
+        // the Prove API, which still lives under /v1/
+        public T BuildV1(string serviceType = null)
+        {
+            var secretKey = string.IsNullOrEmpty(serviceType) ? _options.SecretKey :
+                            serviceType == "connect" ? _options.ConnectSecretKey ?? _options.SecretKey :
+                            serviceType == "lookup" ? _options.LookupSecretKey ?? _options.SecretKey :
+                            throw new ArgumentException("Invalid service type");
+
+            var client = new HttpClient(new HttpClientHandler())
+            {
+                BaseAddress = new Uri(_options.BaseUrl.Replace("v2", "v1"))
             };
             client.DefaultRequestHeaders.Add("mono-sec-key", secretKey);
             var buider = RequestBuilder.ForType<T>(new RefitSettings
@@ -72,6 +99,7 @@ namespace Mono.Core
     {
         T Build(string serviceType = null);
         T BuildV3(string serviceType = null);
+        T BuildV1(string serviceType = null);
     }
 
     public class ServiceTypes

--- a/Mono.Core/Mono.Core.csproj
+++ b/Mono.Core/Mono.Core.csproj
@@ -5,7 +5,7 @@
 			Mono.Core
 		</PackageId>
 		<Version>
-			1.4.0
+			1.5.0
 		</Version>
 		<Authors>
 			Adelowomi

--- a/Mono.Core/Services/Prove/Abstractions/IMonoProve.cs
+++ b/Mono.Core/Services/Prove/Abstractions/IMonoProve.cs
@@ -1,0 +1,55 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Mono.Core.Prove
+{
+    public interface IMonoProve
+    {
+        /// <summary>
+        /// Initiates a Mono Prove KYC verification session. Returns a
+        /// <c>mono_url</c> the customer should be redirected to in order to
+        /// complete verification, plus a <c>session_id</c> for tracking.
+        /// </summary>
+        Task<MonoStandardResponse<InitiateProveResponse>> InitiateProve(
+            InitiateProveModel model,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Retrieves the verification details for a single Prove customer
+        /// (identities, face match, address verification, bank accounts, etc.).
+        /// </summary>
+        Task<MonoStandardResponse<ProveCustomerResponse>> FetchCustomerDetails(
+            string reference,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Lists every Prove customer with optional pagination and filtering.
+        /// </summary>
+        Task<MonoStandardResponse<ProveCustomerListResponse>> FetchAllCustomerDetails(
+            ProveCustomerListQueryOptions options = null,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Blacklists a customer. Provide a <see cref="BlacklistCustomerModel.Reason"/>
+        /// and a <see cref="BlacklistCustomerModel.Code"/> in the 101-105 range.
+        /// </summary>
+        Task<MonoStandardResponse<ProveCustomerResponse>> BlacklistCustomer(
+            BlacklistCustomerModel model,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Reinstates a previously blacklisted customer.
+        /// </summary>
+        Task<MonoStandardResponse<ProveCustomerResponse>> WhitelistCustomer(
+            WhitelistCustomerModel model,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Revokes Mono's permission to share this customer's verification data
+        /// with your business.
+        /// </summary>
+        Task<MonoStandardResponse<dynamic>> RevokeDataAccess(
+            string reference,
+            CancellationToken cancellationToken = default);
+    }
+}

--- a/Mono.Core/Services/Prove/Abstractions/IProveService.cs
+++ b/Mono.Core/Services/Prove/Abstractions/IProveService.cs
@@ -1,0 +1,43 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Refit;
+
+namespace Mono.Core.Prove
+{
+    // Refit interface for the Mono Prove API. Prove still lives under /v1/,
+    // so the high-level facade uses RefitClientBuilder.BuildV1(), which
+    // rewrites BaseUrl's /v2/ to /v1/ before each call. Paths here omit the
+    // version prefix.
+    public interface IProveService
+    {
+        [Post("/prove/initiate")]
+        Task<IApiResponse<MonoStandardResponse<InitiateProveResponse>>> InitiateProve(
+            [Body] InitiateProveModel model,
+            CancellationToken cancellationToken = default);
+
+        [Get("/prove/customers/{reference}")]
+        Task<IApiResponse<MonoStandardResponse<ProveCustomerResponse>>> FetchCustomerDetails(
+            string reference,
+            CancellationToken cancellationToken = default);
+
+        [Get("/prove/customers")]
+        Task<IApiResponse<MonoStandardResponse<ProveCustomerListResponse>>> FetchAllCustomerDetails(
+            [Query] ProveCustomerListQueryOptions options,
+            CancellationToken cancellationToken = default);
+
+        [Post("/prove/customers/blacklist")]
+        Task<IApiResponse<MonoStandardResponse<ProveCustomerResponse>>> BlacklistCustomer(
+            [Body] BlacklistCustomerModel model,
+            CancellationToken cancellationToken = default);
+
+        [Post("/prove/customers/whitelist")]
+        Task<IApiResponse<MonoStandardResponse<ProveCustomerResponse>>> WhitelistCustomer(
+            [Body] WhitelistCustomerModel model,
+            CancellationToken cancellationToken = default);
+
+        [Delete("/prove/customers/{reference}")]
+        Task<IApiResponse<MonoStandardResponse<dynamic>>> RevokeDataAccess(
+            string reference,
+            CancellationToken cancellationToken = default);
+    }
+}

--- a/Mono.Core/Services/Prove/Models/ProveModels.cs
+++ b/Mono.Core/Services/Prove/Models/ProveModels.cs
@@ -1,0 +1,313 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
+
+namespace Mono.Core.Prove
+{
+    // ============ Initiate Prove ============
+
+    public class ProveCustomerIdentity
+    {
+        [Required]
+        [JsonPropertyName("type")]
+        public string Type { get; set; }
+
+        [Required]
+        [JsonPropertyName("number")]
+        public string Number { get; set; }
+    }
+
+    public class ProveCustomer
+    {
+        [Required]
+        [JsonPropertyName("name")]
+        public string Name { get; set; }
+
+        [Required]
+        [JsonPropertyName("phone")]
+        public string Phone { get; set; }
+
+        [Required]
+        [JsonPropertyName("address")]
+        public string Address { get; set; }
+
+        [Required]
+        [JsonPropertyName("email")]
+        public string Email { get; set; }
+
+        [Required]
+        [JsonPropertyName("identity")]
+        public ProveCustomerIdentity Identity { get; set; }
+    }
+
+    public class InitiateProveModel
+    {
+        [Required]
+        [JsonPropertyName("customer")]
+        public ProveCustomer Customer { get; set; }
+
+        [Required]
+        [JsonPropertyName("reference")]
+        public string Reference { get; set; }
+
+        [Required]
+        [JsonPropertyName("redirect_url")]
+        public string RedirectUrl { get; set; }
+
+        /// <summary>"tier_1", "tier_2", "tier_3", or "custom".</summary>
+        [Required]
+        [JsonPropertyName("kyc_level")]
+        public string KycLevel { get; set; }
+
+        /// <summary>Required when <see cref="KycLevel"/> is "custom". Must include at least "bvn" or "nin".</summary>
+        [JsonPropertyName("identities")]
+        public List<string> Identities { get; set; }
+
+        /// <summary>Include bank account verification in the flow.</summary>
+        [JsonPropertyName("bank_accounts")]
+        public bool? BankAccounts { get; set; }
+    }
+
+    public class InitiateProveResponse
+    {
+        [JsonPropertyName("mono_url")]
+        public string MonoUrl { get; set; }
+
+        [JsonPropertyName("session_id")]
+        public string SessionId { get; set; }
+
+        [JsonPropertyName("reference")]
+        public string Reference { get; set; }
+
+        [JsonPropertyName("redirect_url")]
+        public string RedirectUrl { get; set; }
+
+        [JsonPropertyName("created_at")]
+        public DateTime? CreatedAt { get; set; }
+    }
+
+    // ============ Customer details ============
+
+    public class ProveIdentityResult
+    {
+        [JsonPropertyName("type")]
+        public string Type { get; set; }
+
+        [JsonPropertyName("number")]
+        public string Number { get; set; }
+
+        [JsonPropertyName("status")]
+        public string Status { get; set; }
+
+        [JsonPropertyName("first_name")]
+        public string FirstName { get; set; }
+
+        [JsonPropertyName("last_name")]
+        public string LastName { get; set; }
+
+        [JsonPropertyName("middle_name")]
+        public string MiddleName { get; set; }
+
+        [JsonPropertyName("date_of_birth")]
+        public string DateOfBirth { get; set; }
+
+        [JsonPropertyName("gender")]
+        public string Gender { get; set; }
+
+        [JsonPropertyName("phone_number")]
+        public string PhoneNumber { get; set; }
+
+        [JsonPropertyName("photo")]
+        public string Photo { get; set; }
+    }
+
+    public class ProveFaceMatchResult
+    {
+        [JsonPropertyName("status")]
+        public string Status { get; set; }
+
+        [JsonPropertyName("match")]
+        public bool? Match { get; set; }
+
+        [JsonPropertyName("confidence")]
+        public double? Confidence { get; set; }
+
+        [JsonPropertyName("manual_validation")]
+        public bool? ManualValidation { get; set; }
+    }
+
+    public class ProveAddressVerification
+    {
+        [JsonPropertyName("status")]
+        public string Status { get; set; }
+
+        [JsonPropertyName("address")]
+        public string Address { get; set; }
+
+        [JsonPropertyName("confidence")]
+        public double? Confidence { get; set; }
+    }
+
+    public class ProveBankAccount
+    {
+        [JsonPropertyName("account_number")]
+        public string AccountNumber { get; set; }
+
+        [JsonPropertyName("bank_code")]
+        public string BankCode { get; set; }
+
+        [JsonPropertyName("bank_name")]
+        public string BankName { get; set; }
+
+        [JsonPropertyName("account_name")]
+        public string AccountName { get; set; }
+    }
+
+    public class ProveCustomerResponse
+    {
+        [JsonPropertyName("reference")]
+        public string Reference { get; set; }
+
+        [JsonPropertyName("session_id")]
+        public string SessionId { get; set; }
+
+        [JsonPropertyName("status")]
+        public string Status { get; set; }
+
+        [JsonPropertyName("kyc_level")]
+        public string KycLevel { get; set; }
+
+        [JsonPropertyName("customer")]
+        public ProveCustomer Customer { get; set; }
+
+        [JsonPropertyName("identities")]
+        public List<ProveIdentityResult> Identities { get; set; }
+
+        [JsonPropertyName("face_match")]
+        public ProveFaceMatchResult FaceMatch { get; set; }
+
+        [JsonPropertyName("address_verification")]
+        public ProveAddressVerification AddressVerification { get; set; }
+
+        [JsonPropertyName("bank_accounts")]
+        public List<ProveBankAccount> BankAccounts { get; set; }
+
+        [JsonPropertyName("blacklisted")]
+        public bool? Blacklisted { get; set; }
+
+        [JsonPropertyName("blacklist_reason")]
+        public string BlacklistReason { get; set; }
+
+        [JsonPropertyName("blacklist_code")]
+        public int? BlacklistCode { get; set; }
+
+        [JsonPropertyName("created_at")]
+        public DateTime? CreatedAt { get; set; }
+
+        [JsonPropertyName("updated_at")]
+        public DateTime? UpdatedAt { get; set; }
+    }
+
+    public class ProveCustomerListResponse
+    {
+        [JsonPropertyName("customers")]
+        public List<ProveCustomerResponse> Customers { get; set; }
+
+        [JsonPropertyName("meta")]
+        public ProvePaginationMeta Meta { get; set; }
+    }
+
+    public class ProveCustomerListQueryOptions
+    {
+        [JsonPropertyName("page")]
+        public int? Page { get; set; }
+
+        [JsonPropertyName("limit")]
+        public int? Limit { get; set; }
+
+        [JsonPropertyName("status")]
+        public string Status { get; set; }
+
+        [JsonPropertyName("kyc_level")]
+        public string KycLevel { get; set; }
+
+        [JsonPropertyName("blacklisted")]
+        public bool? Blacklisted { get; set; }
+
+        [JsonPropertyName("start")]
+        public string Start { get; set; }
+
+        [JsonPropertyName("end")]
+        public string End { get; set; }
+    }
+
+    public class ProvePaginationMeta
+    {
+        [JsonPropertyName("total")]
+        public long Total { get; set; }
+
+        [JsonPropertyName("page")]
+        public long Page { get; set; }
+
+        [JsonPropertyName("previous")]
+        public string Previous { get; set; }
+
+        [JsonPropertyName("next")]
+        public string Next { get; set; }
+    }
+
+    // ============ Blacklist / Whitelist ============
+
+    public class BlacklistCustomerModel
+    {
+        [Required]
+        [JsonPropertyName("reference")]
+        public string Reference { get; set; }
+
+        [Required]
+        [JsonPropertyName("reason")]
+        public string Reason { get; set; }
+
+        /// <summary>Blacklist reason code in the range 101-105 (per Mono Prove docs).</summary>
+        [Required]
+        [JsonPropertyName("code")]
+        public int Code { get; set; }
+    }
+
+    public class WhitelistCustomerModel
+    {
+        [Required]
+        [JsonPropertyName("reference")]
+        public string Reference { get; set; }
+    }
+
+    // ============ Constants ============
+
+    public class ProveKycLevelConstants
+    {
+        public const string Tier1 = "tier_1";
+        public const string Tier2 = "tier_2";
+        public const string Tier3 = "tier_3";
+        public const string Custom = "custom";
+    }
+
+    public class ProveIdentityTypeConstants
+    {
+        public const string Bvn = "bvn";
+        public const string Nin = "nin";
+    }
+
+    public class ProveBlacklistCodeConstants
+    {
+        // Mono Prove docs specify codes 101-105 without naming them; values
+        // are exposed as-is so callers can pass whatever Mono returns for
+        // their specific reason. Add named constants here once Mono publishes
+        // the mapping.
+        public const int Code101 = 101;
+        public const int Code102 = 102;
+        public const int Code103 = 103;
+        public const int Code104 = 104;
+        public const int Code105 = 105;
+    }
+}

--- a/Mono.Core/Services/Prove/ProveService.cs
+++ b/Mono.Core/Services/Prove/ProveService.cs
@@ -1,0 +1,64 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Mono.Core.Prove
+{
+    public class ProveService : IMonoProve
+    {
+        private readonly IProveService _proveService;
+
+        public ProveService(IRefitClientBuilder<IProveService> proveService)
+        {
+            // Prove still lives under /v1/.
+            _proveService = proveService.BuildV1();
+        }
+
+        public async Task<MonoStandardResponse<InitiateProveResponse>> InitiateProve(
+            InitiateProveModel model,
+            CancellationToken cancellationToken = default)
+        {
+            var response = await _proveService.InitiateProve(model, cancellationToken);
+            return response.HandleResponse();
+        }
+
+        public async Task<MonoStandardResponse<ProveCustomerResponse>> FetchCustomerDetails(
+            string reference,
+            CancellationToken cancellationToken = default)
+        {
+            var response = await _proveService.FetchCustomerDetails(reference, cancellationToken);
+            return response.HandleResponse();
+        }
+
+        public async Task<MonoStandardResponse<ProveCustomerListResponse>> FetchAllCustomerDetails(
+            ProveCustomerListQueryOptions options = null,
+            CancellationToken cancellationToken = default)
+        {
+            var response = await _proveService.FetchAllCustomerDetails(options ?? new ProveCustomerListQueryOptions(), cancellationToken);
+            return response.HandleResponse();
+        }
+
+        public async Task<MonoStandardResponse<ProveCustomerResponse>> BlacklistCustomer(
+            BlacklistCustomerModel model,
+            CancellationToken cancellationToken = default)
+        {
+            var response = await _proveService.BlacklistCustomer(model, cancellationToken);
+            return response.HandleResponse();
+        }
+
+        public async Task<MonoStandardResponse<ProveCustomerResponse>> WhitelistCustomer(
+            WhitelistCustomerModel model,
+            CancellationToken cancellationToken = default)
+        {
+            var response = await _proveService.WhitelistCustomer(model, cancellationToken);
+            return response.HandleResponse();
+        }
+
+        public async Task<MonoStandardResponse<dynamic>> RevokeDataAccess(
+            string reference,
+            CancellationToken cancellationToken = default)
+        {
+            var response = await _proveService.RevokeDataAccess(reference, cancellationToken);
+            return response.HandleResponse();
+        }
+    }
+}

--- a/Readme.md
+++ b/Readme.md
@@ -13,6 +13,7 @@ Mono.Core is a .NET library that provides services and utilities for Mono accoun
 - [IMonoDisburse](#imonodisburse)
 - [IMonoLookUp](#imonolookup)
 - [IMonoMiscellaneous](#imonomiscellaneous)
+- [IMonoProve](#imonoprove)
 - [IMonoWatchlist](#imonowatchlist)
 
 ## Configuration
@@ -275,6 +276,45 @@ This interface provides methods for looking up information in Mono.
 - `GetCreditHistory` This method enables you to retrieve a user's credit history.
 - `GetMashUp` This method allows you to verify the NIN, BVN and date of birth of your user in one API call for KYC.
 
+### IMonoProve
+
+This interface wraps the Mono Prove API (`/v1/prove/...`) — Mono's full-stack KYC verification (BVN/NIN ownership, government-ID + face match, address verification, optional bank-account linking).
+
+Flow: call `InitiateProve` → redirect the customer to the returned `mono_url` → poll `FetchCustomerDetails` (or wait for the webhook) for verification results.
+
+- `InitiateProve` Starts a verification session. Pick a `KycLevel` (`tier_1`/`tier_2`/`tier_3`/`custom`).
+- `FetchCustomerDetails` Pulls the full verification record by reference (identities, face match, address, bank accounts).
+- `FetchAllCustomerDetails` Lists every Prove customer with optional filters.
+- `BlacklistCustomer` Marks a customer as blacklisted with a reason + code (101-105).
+- `WhitelistCustomer` Reinstates a previously blacklisted customer.
+- `RevokeDataAccess` Revokes Mono's permission to share this customer's data with your business.
+
+```csharp
+using Mono.Core.Prove;
+
+var prove = await _prove.InitiateProve(new InitiateProveModel
+{
+    Customer = new ProveCustomer
+    {
+        Name = "Ada Lovelace",
+        Phone = "+2348012345678",
+        Address = "12 Analytical St, Lagos",
+        Email = "ada@example.com",
+        Identity = new ProveCustomerIdentity
+        {
+            Type = ProveIdentityTypeConstants.Bvn,
+            Number = "12345678901",
+        },
+    },
+    Reference = "kyc-ada-2026-05",
+    RedirectUrl = "https://yourapp.com/kyc/done",
+    KycLevel = ProveKycLevelConstants.Tier2,
+});
+
+// later, after the customer completes the flow:
+var details = await _prove.FetchCustomerDetails("kyc-ada-2026-05");
+```
+
 ### IMonoWatchlist
 
 This interface wraps the Mono Watchlist Screening API (`/v3/lookup/watchlist/...`) — sanctions, PEP and adverse-media screening with risk scores, batch screening, an audit log per screening, PDF compliance reports, and ongoing monitoring.
@@ -315,6 +355,30 @@ This interface provides miscellaneous methods for managing Mono.
 - `GetCacLookup` This method to retieve cac lookup information.
 - `GetCacCompany` This method is use to retrieve shareholder information of a company.
 - `UnLinkAccount` This method provide you with the option to unlink their financial account(s).
+
+## Changes in 1.5.0 (May 2026)
+
+Adds the Mono Prove API surface — full-stack KYC verification (BVN/NIN ownership, government-ID + face match, address verification, optional bank-account linking).
+
+**New `IMonoProve` interface — 6 endpoints under `/v1/prove/...`:**
+- `InitiateProve` (POST `/prove/initiate`)
+- `FetchCustomerDetails` (GET `/prove/customers/{reference}`)
+- `FetchAllCustomerDetails` (GET `/prove/customers`)
+- `BlacklistCustomer` (POST `/prove/customers/blacklist`)
+- `WhitelistCustomer` (POST `/prove/customers/whitelist`)
+- `RevokeDataAccess` (DELETE `/prove/customers/{reference}`)
+
+**Infrastructure:**
+- `IRefitClientBuilder<T>` gains `BuildV1(string)` — Prove still lives under `/v1/`. Pattern matches the existing `BuildV3` helper (rewrites the `/v2/` in `BaseUrl` to `/v1/`).
+
+**Registration:**
+- `AddMono(...)` now also wires up `IMonoProve`
+- Standalone `AddMonoProve(...)` extension available
+
+**Constants:**
+- `ProveKycLevelConstants` (`tier_1` / `tier_2` / `tier_3` / `custom`)
+- `ProveIdentityTypeConstants` (`bvn` / `nin`)
+- `ProveBlacklistCodeConstants` (101-105 — passed through verbatim; Mono hasn't published a named mapping)
 
 ## Changes in 1.4.0 (May 2026)
 


### PR DESCRIPTION
## Summary

Adds the Mono **Prove API** — full-stack KYC verification. Prove combines BVN/NIN ownership checks, government-ID + face match, address verification, and optional bank-account linking into a single redirect-based customer flow.

Typical use: customer hits your onboarding screen → you call `InitiateProve` → redirect them to the returned `mono_url` → they complete the flow → you poll `FetchCustomerDetails` (or wait for the webhook) for the verification record.

## New surface — `IMonoProve` (6 endpoints, all v1)

| Method | Endpoint | Notes |
|---|---|---|
| `InitiateProve` | POST `/prove/initiate` | Returns `mono_url`, `session_id`, `reference` |
| `FetchCustomerDetails` | GET `/prove/customers/{reference}` | Full verification record |
| `FetchAllCustomerDetails` | GET `/prove/customers` | Paginated list with filters |
| `BlacklistCustomer` | POST `/prove/customers/blacklist` | Body: `reference`, `reason`, `code` (101-105) |
| `WhitelistCustomer` | POST `/prove/customers/whitelist` | Body: `reference` |
| `RevokeDataAccess` | DELETE `/prove/customers/{reference}` | Revokes data-sharing |

## KYC levels

`InitiateProveModel.KycLevel` supports four values via `ProveKycLevelConstants`:

| Constant | API value | Coverage |
|---|---|---|
| `Tier1` | `tier_1` | BVN/NIN ownership validation |
| `Tier2` | `tier_2` | Tier 1 + government-ID with facial recognition |
| `Tier3` | `tier_3` | Tier 2 + address + residency confirmation |
| `Custom` | `custom` | Requires `Identities` array (must include `bvn` or `nin`) |

## Infrastructure change: `BuildV1()`

Prove still lives under `/v1/` while the rest of the library targets `/v2/` (with mandates/disburse/lookups on `/v3/`). Added `BuildV1(string)` to `IRefitClientBuilder<T>` mirroring the existing `BuildV3` pattern — rewrites the `/v2/` segment in `BaseUrl` to `/v1/` per request.

```csharp
// IRefitClientBuilder<T>
T Build(string serviceType = null);    // /v2/
T BuildV3(string serviceType = null);  // /v3/
T BuildV1(string serviceType = null);  // /v1/  ← new
```

No existing service is affected.

## DI

- `AddMono(...)` now also registers `IMonoProve`
- Standalone `AddMonoProve(...)` follows the existing per-service registration pattern

## Constants

- `ProveKycLevelConstants` — `tier_1` / `tier_2` / `tier_3` / `custom`
- `ProveIdentityTypeConstants` — `bvn` / `nin`
- `ProveBlacklistCodeConstants` — 101 through 105 (pass-through; Mono hasn't published a named mapping for the codes, only the valid range)

## Code layout

```
Mono.Core/Services/Prove/
├── Abstractions/
│   ├── IProveService.cs   (Refit interface — v1)
│   └── IMonoProve.cs       (high-level interface)
├── Models/
│   └── ProveModels.cs       (requests, responses, constants)
└── ProveService.cs           (high-level implementation)
```

## Compat

- Pure additive — the new `BuildV1` is a fresh method on `IRefitClientBuilder<T>` so no existing service implementation needs to change
- Package version: 1.4.0 → 1.5.0 (minor bump)

## Test plan

- [x] `dotnet build` — succeeds with 0 errors and 0 warnings
- [ ] Sandbox smoke-test before NuGet publish:
  - [ ] Initiate a tier_1 session, redirect through sandbox, fetch the resulting customer record
  - [ ] Initiate a tier_2 session; verify `face_match` block populates after the flow completes
  - [ ] Initiate a `custom` session with `Identities = ["bvn", "nin"]`; confirm both identity results come back
  - [ ] Blacklist + whitelist a customer; confirm both `blacklisted` and `blacklist_code` round-trip
  - [ ] Revoke data access; confirm subsequent `FetchCustomerDetails` returns 404
- [ ] Response-shape verification (Mono's public docs didn't expose full 200 schemas):
  - [ ] `identities[]` items — modeled as `ProveIdentityResult` with type/number/status + identity fields; verify against sandbox
  - [ ] `face_match` block — assumed `status`, `match`, `confidence`, `manual_validation`
  - [ ] `address_verification` block — assumed `status`, `address`, `confidence`
  - [ ] `bank_accounts[]` — assumed flat list under that key
  - [ ] Customer list response wrapper — `customers[]` + `meta` (consistent with Mono's other list endpoints)

## Follow-up PRs still queued

- **Connect additions**: real-time `account-balance`, Account Match, Get-All-Accounts at the Account layer
- **NIN poll-job** endpoint + `output=pdf`
- **CAC**: PSC, Profile, Status-Report (replaces the deprecated change-of-name / previous-address)
- **DirectPay**: Refund, Payout (by status), Payout Transactions
- **Webhook hardening**: `mono-webhook-secret` signature verification, new event types (Prove verification webhooks, Watchlist match, Disburse, mandate `debit.successful`, income, creditworthiness), `event_id` + `timestamp` on payloads

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add a new Mono Prove KYC verification API surface and supporting infrastructure while keeping existing services unchanged.

New Features:
- Introduce the IMonoProve high-level interface and underlying IProveService Refit client exposing six Prove endpoints for initiating, retrieving, listing, blacklisting, whitelisting, and revoking KYC verification sessions.
- Add comprehensive Prove request/response models, pagination types, and constants for KYC levels, identity types, and blacklist codes.
- Provide a standalone AddMonoProve DI registration alongside wiring IMonoProve into the main AddMono extension.

Enhancements:
- Extend IRefitClientBuilder<T> with a BuildV1 helper to target Mono APIs still served under the /v1/ base path.
- Update the README with IMonoProve usage documentation, including code samples and a 1.5.0 changelog entry describing the new Prove surface.

Build:
- Bump the Mono.Core package version from 1.4.0 to 1.5.0 to reflect the new Prove capability.