### PR TITLE
Add Connect additions: real-time balance, Account Match, NIN PDF + poll job (v1.6.0)

### DIFF
--- a/Mono.Core/Mono.Core.csproj
+++ b/Mono.Core/Mono.Core.csproj
@@ -5,7 +5,7 @@
 			Mono.Core
 		</PackageId>
 		<Version>
-			1.5.0
+			1.6.0
 		</Version>
 		<Authors>
 			Adelowomi

--- a/Mono.Core/Services/Account/Abstractions/IAccountService.cs
+++ b/Mono.Core/Services/Account/Abstractions/IAccountService.cs
@@ -27,5 +27,9 @@ namespace Mono.Core.Accounts
         // accounts/{accountId}/transactions?start={start}&end={end}&narration={narration}&type={type}&paginate={paginate}&limit={limit}
         [Get("/accounts/{accountId}/transactions")]
         Task<IApiResponse<MonoStandardResponse<TransactionResponseModel>>> GetTransactions(string accountId, [Query] AccountTransactionsOptionsRequest accountTransactionsOptionsRequest, CancellationToken cancellationToken = default);
+
+        // /accounts/{accountId}/balance — real-time balance (Feb 2025)
+        [Get("/accounts/{accountId}/balance")]
+        Task<IApiResponse<MonoStandardResponse<AccountBalanceResponse>>> GetAccountBalance(string accountId, CancellationToken cancellationToken = default);
     }
 }

--- a/Mono.Core/Services/Account/Abstractions/IMonoAccounts.cs
+++ b/Mono.Core/Services/Account/Abstractions/IMonoAccounts.cs
@@ -56,5 +56,14 @@ namespace Mono.Core.Accounts
         /// <param name="cancellationToken">A Cancellation token that can be used to cancel the task. This will terminate the HTTP request if triggered.</param>
         /// <returns>A task that represents the asynchronous operation. The task result contains a MonoStandardResponse with a TransactionResponseModel.</returns>
         Task<MonoStandardResponse<TransactionResponseModel>> GetTransactions(string accountId, AccountTransactionsOptionsRequest accountTransactionsOptionsRequest, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Retrieves the real-time balance for an account. Triggers a live fetch
+        /// from the financial institution and may incur a per-call fee depending
+        /// on your Mono plan.
+        /// </summary>
+        /// <param name="accountId">The ID of the account to fetch the balance for.</param>
+        /// <param name="cancellationToken">A Cancellation token that can be used to cancel the task.</param>
+        Task<MonoStandardResponse<AccountBalanceResponse>> GetAccountBalance(string accountId, CancellationToken cancellationToken = default);
     }
 }

--- a/Mono.Core/Services/Account/AccountService.cs
+++ b/Mono.Core/Services/Account/AccountService.cs
@@ -57,5 +57,11 @@ namespace Mono.Core.Accounts
              return response.HandleResponse();
         }
 
+        public async Task<MonoStandardResponse<AccountBalanceResponse>> GetAccountBalance(string accountId, CancellationToken cancellationToken = default)
+        {
+            var response = await _accountService.GetAccountBalance(accountId, cancellationToken);
+            return response.HandleResponse();
+        }
+
     }
 }

--- a/Mono.Core/Services/Account/Models/AccountBalanceResponse.cs
+++ b/Mono.Core/Services/Account/Models/AccountBalanceResponse.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Text.Json.Serialization;
+
+namespace Mono.Core.Accounts
+{
+    /// <summary>
+    /// Response shape for the real-time balance endpoint (GET /accounts/{id}/balance).
+    /// </summary>
+    public class AccountBalanceResponse
+    {
+        [JsonPropertyName("id")]
+        public string Id { get; set; }
+
+        [JsonPropertyName("account_number")]
+        public string AccountNumber { get; set; }
+
+        [JsonPropertyName("name")]
+        public string Name { get; set; }
+
+        [JsonPropertyName("currency")]
+        public string Currency { get; set; }
+
+        /// <summary>Balance in minor units (kobo for NGN, pesewa for GHS, cents for KES/ZAR).</summary>
+        [JsonPropertyName("balance")]
+        public long? Balance { get; set; }
+
+        /// <summary>Funds available for withdrawal (subset of <see cref="Balance"/>).</summary>
+        [JsonPropertyName("available_balance")]
+        public long? AvailableBalance { get; set; }
+
+        [JsonPropertyName("last_updated")]
+        public DateTime? LastUpdated { get; set; }
+    }
+}

--- a/Mono.Core/Services/Account/Models/AccountLinkingModel.cs
+++ b/Mono.Core/Services/Account/Models/AccountLinkingModel.cs
@@ -13,6 +13,41 @@ namespace Mono.Core.Accounts
         public string Scope { get; set; }
         [JsonPropertyName("redirect_url")]
         public string RedirectUrl { get; set; }
+
+        /// <summary>
+        /// Optional. Pin the linking flow to a specific institution + account
+        /// (e.g. for Account Match verification). When provided alongside
+        /// <see cref="CheckAccountMatch"/> = true, Mono confirms the linked
+        /// account number matches <see cref="AccountLinkingInstitution.AccountNumber"/>
+        /// and reports the result on the <c>account_match</c> field of the
+        /// <c>mono.events.account_updated</c> webhook.
+        /// </summary>
+        [JsonPropertyName("institution")]
+        public AccountLinkingInstitution Institution { get; set; }
+
+        /// <summary>
+        /// Optional. Set true to enable Account Match (Feb 2026). Verifies the
+        /// account number the customer links matches the one supplied in
+        /// <see cref="Institution"/>; result is delivered on the
+        /// <c>mono.events.account_updated</c> webhook.
+        /// </summary>
+        [JsonPropertyName("check_account_match")]
+        public bool? CheckAccountMatch { get; set; }
+    }
+
+    public class AccountLinkingInstitution
+    {
+        /// <summary>Mono institution id or bank code. Required for Account Match.</summary>
+        [JsonPropertyName("id")]
+        public string Id { get; set; }
+
+        /// <summary>Customer's account number — Mono compares the linked account to this value.</summary>
+        [JsonPropertyName("account_number")]
+        public string AccountNumber { get; set; }
+
+        /// <summary>Optional auth method override (e.g. <c>internet_banking</c>).</summary>
+        [JsonPropertyName("auth_method")]
+        public string AuthMethod { get; set; }
     }
 
     public class Customer

--- a/Mono.Core/Services/LookUp/Abstractions/ILookUpService.cs
+++ b/Mono.Core/Services/LookUp/Abstractions/ILookUpService.cs
@@ -74,6 +74,14 @@ namespace Mono.Core.LookUp
         [Post("/lookup/nin")]
         Task<IApiResponse<MonoStandardResponse<NinResponseModel>>> GetNin([Body] NinRequestModel ninLookUpRequestModel, CancellationToken cancellationToken = default);
 
+        // /lookup/nin with output=pdf — async, returns a job id to poll
+        [Post("/lookup/nin")]
+        Task<IApiResponse<MonoStandardResponse<NinPdfJobInitiationResponse>>> GetNinPdf([Body] NinPdfRequestModel ninPdfRequestModel, CancellationToken cancellationToken = default);
+
+        // /lookup/nin/{jobId}/job — poll the NIN PDF job
+        [Get("/lookup/nin/{jobId}/job")]
+        Task<IApiResponse<MonoStandardResponse<NinPollJobResponse>>> PollNinJob(string jobId, CancellationToken cancellationToken = default);
+
         // /lookup/drivers-license (renamed from driver_license per current Mono lookup docs)
         [Post("/lookup/drivers-license")]
         Task<IApiResponse<MonoStandardResponse<DriversLicenseResponse>>> GetDriverLicense([Body] DriversLicenseRequestModel driverLicenseLookUpRequestModel, CancellationToken cancellationToken = default);

--- a/Mono.Core/Services/LookUp/Abstractions/IMonoLookUpService.cs
+++ b/Mono.Core/Services/LookUp/Abstractions/IMonoLookUpService.cs
@@ -146,5 +146,18 @@ namespace Mono.Core.LookUp
         /// <param name="cancellationToken">A Cancellation token that can be used to cancel the task. This will terminate the HTTP request.</param>
         /// <returns>A task that represents the asynchronous operation, containing a MonoStandardResponse with a MashUpResponse.</returns>
         Task<MonoStandardResponse<MashUpResponse>> GetMashUp(MashUpRequestModel mashUpLookUpRequestModel, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Submits a NIN lookup with <c>output=pdf</c>. Mono runs the lookup
+        /// asynchronously and returns a job id; poll <see cref="PollNinJob"/>
+        /// until status is <c>completed</c> to get a download URL.
+        /// </summary>
+        Task<MonoStandardResponse<NinPdfJobInitiationResponse>> GetNinPdf(NinPdfRequestModel ninPdfRequestModel, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Polls a NIN PDF generation job by id. Returns <c>processing</c> until
+        /// the PDF is ready, then <c>completed</c> with a 7-day download URL.
+        /// </summary>
+        Task<MonoStandardResponse<NinPollJobResponse>> PollNinJob(string jobId, CancellationToken cancellationToken = default);
     }
 }

--- a/Mono.Core/Services/LookUp/LookUpService.cs
+++ b/Mono.Core/Services/LookUp/LookUpService.cs
@@ -134,5 +134,17 @@ namespace Mono.Core.LookUp
              return response.HandleResponse();
         }
 
+        public async Task<MonoStandardResponse<NinPdfJobInitiationResponse>> GetNinPdf(NinPdfRequestModel ninPdfRequestModel, CancellationToken cancellationToken = default)
+        {
+            var response = await _lookUpServiceV3.GetNinPdf(ninPdfRequestModel, cancellationToken);
+            return response.HandleResponse();
+        }
+
+        public async Task<MonoStandardResponse<NinPollJobResponse>> PollNinJob(string jobId, CancellationToken cancellationToken = default)
+        {
+            var response = await _lookUpServiceV3.PollNinJob(jobId, cancellationToken);
+            return response.HandleResponse();
+        }
+
     }
 }

--- a/Mono.Core/Services/LookUp/Models/CacLookUpModels.cs
+++ b/Mono.Core/Services/LookUp/Models/CacLookUpModels.cs
@@ -527,6 +527,66 @@ namespace Mono.Core.LookUp
         [JsonPropertyName("nin")]
         public string Nin { get; set; }
     }
+
+    /// <summary>
+    /// NIN lookup request with <c>output=pdf</c>. Mono runs the lookup asynchronously
+    /// and returns a job id; poll <c>GET /lookup/nin/{jobId}/job</c> until completion.
+    /// PDFs remain downloadable for 7 days after generation.
+    /// </summary>
+    public class NinPdfRequestModel
+    {
+        [JsonPropertyName("nin")]
+        public string Nin { get; set; }
+
+        [JsonPropertyName("output")]
+        public string Output { get; set; } = NinOutputConstants.Pdf;
+    }
+
+    public class NinOutputConstants
+    {
+        public const string Json = "json";
+        public const string Pdf = "pdf";
+    }
+
+    /// <summary>
+    /// Initial response from a PDF-output NIN lookup — only carries the job
+    /// metadata. Poll <c>GET /lookup/nin/{jobId}/job</c> for the completed result.
+    /// </summary>
+    public class NinPdfJobInitiationResponse
+    {
+        [JsonPropertyName("job_id")]
+        public string JobId { get; set; }
+
+        [JsonPropertyName("status")]
+        public string Status { get; set; }
+    }
+
+    /// <summary>
+    /// Result of polling a NIN PDF job. Once <c>Status == "completed"</c>,
+    /// <see cref="Url"/> contains a 7-day-expiry download link and
+    /// <see cref="Result"/> the parsed NIN details.
+    /// </summary>
+    public class NinPollJobResponse
+    {
+        [JsonPropertyName("job_id")]
+        public string JobId { get; set; }
+
+        [JsonPropertyName("status")]
+        public string Status { get; set; }
+
+        [JsonPropertyName("url")]
+        public string Url { get; set; }
+
+        [JsonPropertyName("result")]
+        public NinResponseModel Result { get; set; }
+    }
+
+    public class NinJobStatusConstants
+    {
+        public const string Processing = "processing";
+        public const string Completed = "completed";
+        public const string Failed = "failed";
+    }
     public class NinResponseModel
     {
         [JsonPropertyName("birthcountry")]

--- a/Mono.Core/Services/WebHookService/Models/MonoWebhookModel.cs
+++ b/Mono.Core/Services/WebHookService/Models/MonoWebhookModel.cs
@@ -55,6 +55,34 @@ namespace Mono.Core.Webhooks
 
         [JsonPropertyName("account")]
         public Account Account { get; set; }
+
+        /// <summary>
+        /// Account Match verification result (Feb 2026). Populated only when
+        /// the linking request set <c>check_account_match=true</c>.
+        /// </summary>
+        [JsonPropertyName("account_match")]
+        public AccountMatchResult AccountMatch { get; set; }
+    }
+
+    public class AccountMatchResult
+    {
+        /// <summary>"matched" or "not_matched".</summary>
+        [JsonPropertyName("status")]
+        public string Status { get; set; }
+
+        [JsonPropertyName("matched")]
+        public bool? Matched { get; set; }
+
+        /// <summary>Account number the customer was asked to match against.</summary>
+        [JsonPropertyName("expected_account_number")]
+        public string ExpectedAccountNumber { get; set; }
+
+        /// <summary>Account number that was actually linked.</summary>
+        [JsonPropertyName("linked_account_number")]
+        public string LinkedAccountNumber { get; set; }
+
+        [JsonPropertyName("reason")]
+        public string Reason { get; set; }
     }
 
     public class Institution

--- a/Readme.md
+++ b/Readme.md
@@ -150,8 +150,9 @@ You can read the mono documentation [here](https://docs.mono.co/api)
 
 This interface provides methods for managing accounts in Mono.
 
-- `InitiateAccountLinking` This method is to initiate linking an account.
+- `InitiateAccountLinking` This method is to initiate linking an account. Supports Account Match — set `Institution.AccountNumber` and `CheckAccountMatch=true` to have Mono verify the linked account against the expected number, with the result delivered on the `account_updated` webhook.
 - `GetAccount` This method provides account information of a specific account .
+- `GetAccountBalance` Real-time balance for a connected account (live fetch from the bank; may incur a per-call fee).
 - `GetPollStatementPdf` This method is use to retrieve the statement Pdf of an account, when output is set as PDF.
 - `GetIncome` This method is use to retrieve income information of a specific account.
 - `GetIdentity` This method provides a mini customer identity information.
@@ -275,6 +276,8 @@ This interface provides methods for looking up information in Mono.
 - `GetAccountNumber` This method verifies the account and returns the masked BVN attached to the account number supplied.
 - `GetCreditHistory` This method enables you to retrieve a user's credit history.
 - `GetMashUp` This method allows you to verify the NIN, BVN and date of birth of your user in one API call for KYC.
+- `GetNinPdf` Submits a NIN lookup with `output=pdf`. Returns a job id; poll with `PollNinJob`.
+- `PollNinJob` Polls a NIN PDF generation job. Returns `processing` until ready, then `completed` with a 7-day-expiry download URL.
 
 ### IMonoProve
 
@@ -355,6 +358,25 @@ This interface provides miscellaneous methods for managing Mono.
 - `GetCacLookup` This method to retieve cac lookup information.
 - `GetCacCompany` This method is use to retrieve shareholder information of a company.
 - `UnLinkAccount` This method provide you with the option to unlink their financial account(s).
+
+## Changes in 1.6.0 (May 2026)
+
+Connect additions — fills gaps in existing services rather than adding new product surfaces.
+
+**`IMonoAccounts`:**
+- `GetAccountBalance` (GET `/accounts/{id}/balance`) — real-time balance fetch
+- `AccountLinkingModel` gains `Institution` and `CheckAccountMatch` for the Feb 2026 Account Match feature; result arrives on the existing `account_updated` webhook
+- `AccountUpdatedEventModel` gains `AccountMatch` (status, matched bool, expected vs linked account numbers, reason)
+
+**`IMonoLookUp`:**
+- `GetNinPdf` (POST `/lookup/nin` with `output=pdf`) — async NIN lookup returning a job id
+- `PollNinJob` (GET `/lookup/nin/{jobId}/job`) — poll status; completed jobs include a 7-day download URL
+
+**Constants:**
+- `NinOutputConstants` (`json` / `pdf`)
+- `NinJobStatusConstants` (`processing` / `completed` / `failed`)
+
+**Not duplicated:** Get-All-Accounts is already exposed as `IMonoCustomers.FetchAllLinkedAccounts` (v1.2.0). Mono files that endpoint under Customer; the path is `/accounts`.
 
 ## Changes in 1.5.0 (May 2026)
 


### PR DESCRIPTION
## Summary

Fills gaps in existing services rather than adding new product surfaces. Three additions across two services, plus a small webhook payload extension. All purely additive — no breaking changes.

## `IMonoAccounts`

### Real-time balance — `GetAccountBalance`
| Method | Endpoint |
|---|---|
| `GetAccountBalance` | GET `/accounts/{id}/balance` |

Distinct from the cached balance returned by `GetAccount`: this one triggers a live fetch from the bank. May incur a per-call fee depending on your Mono plan.

Returns `AccountBalanceResponse` with `id`, `account_number`, `name`, `currency`, `balance`, `available_balance`, `last_updated`. Balances are in minor units (kobo / pesewa / cents).

### Account Match (Feb 2026)
Account Match is a flag on the **existing** `InitiateAccountLinking` endpoint, not a new route. Added two fields to `AccountLinkingModel`:

```csharp
new AccountLinkingModel
{
    Customer = ...,
    Scope = ...,
    RedirectUrl = ...,
    Institution = new AccountLinkingInstitution
    {
        Id = "057",                          // bank code or Mono institution id
        AccountNumber = "0123456789",        // expected account number
    },
    CheckAccountMatch = true,
};
```

Result arrives on the existing `mono.events.account_updated` webhook, on a new `account_match` field. Extended `AccountUpdatedEventModel` to capture it:

```csharp
public class AccountMatchResult
{
    public string Status { get; set; }              // "matched" | "not_matched"
    public bool? Matched { get; set; }
    public string ExpectedAccountNumber { get; set; }
    public string LinkedAccountNumber { get; set; }
    public string Reason { get; set; }
}
```

## `IMonoLookUp`

### NIN PDF lookup + poll job
| Method | Endpoint | Purpose |
|---|---|---|
| `GetNinPdf` | POST `/lookup/nin` with `output=pdf` | Async — returns a job id |
| `PollNinJob` | GET `/lookup/nin/{jobId}/job` | Poll until `completed`; response carries a 7-day-expiry download URL |

Modeled as two separate methods rather than overloading the existing `GetNin` because the response shape changes when `output=pdf` (job id + status vs the full NIN record). Two distinct method signatures keep callers strongly typed for both flows.

```csharp
var job = await _lookup.GetNinPdf(new NinPdfRequestModel { Nin = "12345678901" });
// ... poll until completed:
var poll = await _lookup.PollNinJob(job.Data.JobId);
if (poll.Data.Status == NinJobStatusConstants.Completed)
{
    var pdfUrl = poll.Data.Url; // 7-day expiry
}
```

## Constants added

- `NinOutputConstants` — `json` / `pdf`
- `NinJobStatusConstants` — `processing` / `completed` / `failed`

## Why no Get-All-Accounts

That gap from the original audit was already filled in v1.2.0 as `IMonoCustomers.FetchAllLinkedAccounts`. Mono documents `/accounts` (list all linked accounts) under the **Customer** product even though the path is global. Adding it to `IMonoAccounts` too would be a duplicate, so I left it alone.

## Compat

- Pure additive — every change is a new method, new property on an existing model, or a new model. No existing call sites need to change.
- Package version: 1.5.0 → 1.6.0

## Test plan

- [x] `dotnet build` — succeeds, 0 errors, 0 warnings
- [ ] Sandbox smoke-test before NuGet publish:
  - [ ] `GetAccountBalance` returns a live balance distinct from `GetAccount`'s cached value
  - [ ] `InitiateAccountLinking` with `CheckAccountMatch=true` produces an `account_match` payload on the `account_updated` webhook
  - [ ] `GetNinPdf` returns a `job_id` and `status=processing`
  - [ ] `PollNinJob` flips to `status=completed` with a downloadable `url`
- [ ] Response-shape verification (Mono's public docs didn't expose full 200 schemas):
  - [ ] `AccountBalanceResponse` field names — `available_balance` vs `available`
  - [ ] `AccountMatchResult.Status` values — confirm `matched`/`not_matched` vs alternatives like `match`/`no_match`
  - [ ] `NinPollJobResponse.Result` — confirm the parsed NIN object is nested under `result` vs flattened

## Follow-up PRs still queued

- **CAC**: PSC, Profile, Status-Report (replaces deprecated change-of-name / previous-address)
- **DirectPay**: Refund, Payout (by status), Payout Transactions
- **Webhook hardening**: `mono-webhook-secret` signature verification, new event types (Watchlist match, Disburse, Prove verification, mandate `debit.successful`, income, creditworthiness), `event_id` + `timestamp` on all payloads, fix the `_eventType` race in `MonoWebhookController`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add new Connect capabilities for real-time account balances, account match verification, and asynchronous NIN PDF lookups while preserving backwards compatibility.

New Features:
- Expose a real-time account balance endpoint via IMonoAccounts and AccountService with a new AccountBalanceResponse model.
- Extend account linking to support Account Match by specifying an institution and expected account number, with results surfaced on the account_updated webhook.
- Introduce asynchronous NIN PDF lookup and polling APIs in IMonoLookUp and LookUpService, including typed request/response models and status constants.

Enhancements:
- Update public README documentation with the new account balance, Account Match, and NIN PDF lookup features plus a 1.6.0 changelog section.

Documentation:
- Document new account balance, Account Match, and NIN PDF lookup methods and behavior in the README, including webhook behavior and job polling semantics.