### PR TITLE
Webhook hardening: signature verification + routing fix + new events (v1.7.0)

### DIFF
--- a/Mono.Core.Tests/Controllers/WebhookControllerTests.cs
+++ b/Mono.Core.Tests/Controllers/WebhookControllerTests.cs
@@ -1,5 +1,7 @@
 ﻿using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Mono.Core;
 using Mono.Core.Webhooks;
 using Moq;
 using Xunit;
@@ -18,7 +20,10 @@ public class WebhookControllerTests
     {
         _webhookConsumerMock = new Mock<IMonoWebhookConsumer>();
         _loggerMock = new Mock<ILogger<MonoWebhookController>>();
-        _webhookController = new MonoWebhookController(_webhookConsumerMock.Object, _loggerMock.Object);
+        // Leave WebhookSecret unset so signature verification is in opt-in
+        // (warn-and-pass) mode for these tests.
+        var options = Options.Create(new MonoInitializationOptions());
+        _webhookController = new MonoWebhookController(_webhookConsumerMock.Object, _loggerMock.Object, options);
     }
 
     [Fact]

--- a/Mono.Core/Models/UtilityModels/MonoIntializationOptions.cs
+++ b/Mono.Core/Models/UtilityModels/MonoIntializationOptions.cs
@@ -6,5 +6,15 @@
         public string BaseUrl { get; set; }
         public string ConnectSecretKey { get; set; }
         public string LookupSecretKey { get; set; }
+
+        /// <summary>
+        /// Shared secret configured on the Mono webhook dashboard. When set,
+        /// <see cref="Mono.Core.Webhooks.MonoWebhookController"/> rejects any
+        /// inbound POST whose <c>mono-webhook-secret</c> header doesn't match
+        /// (HTTP 401). When null or empty the controller logs a warning and
+        /// processes the request anyway — opt-in for backward compatibility,
+        /// but you should set this in production.
+        /// </summary>
+        public string WebhookSecret { get; set; }
     }
 }

--- a/Mono.Core/Mono.Core.csproj
+++ b/Mono.Core/Mono.Core.csproj
@@ -5,7 +5,7 @@
 			Mono.Core
 		</PackageId>
 		<Version>
-			1.6.0
+			1.7.0
 		</Version>
 		<Authors>
 			Adelowomi

--- a/Mono.Core/Services/WebHookService/IWebhookConsumer.cs
+++ b/Mono.Core/Services/WebHookService/IWebhookConsumer.cs
@@ -10,8 +10,30 @@ namespace Mono.Core
         Task HandleAccountUpdatedEvent(AccountUpdatedEventModel webhook);
         Task HandleMandateCreatedEvent(MandateCreatedEventModel webhook);
         Task HandleMandateApprovedEvent(MandateApprovedEventModel webhook);
-        Task HandleMandateReadyEvent(MandateReadyEventModel webhook); 
+        Task HandleMandateReadyEvent(MandateReadyEventModel webhook);
 
         Task HandleUnknownEvent(string json);
+    }
+
+    /// <summary>
+    /// Optional handler surface for the newer Mono webhook events
+    /// (debit.successful / debit.failed, account_income, creditworthiness,
+    /// disbursement.*, watchlist.match_found, prove.completed / prove.failed).
+    ///
+    /// Implement this interface on the same class as <see cref="IMonoWebhookConsumer"/>;
+    /// the controller will dispatch automatically. Consumers that don't implement
+    /// it receive these events via <see cref="IMonoWebhookConsumer.HandleUnknownEvent"/>
+    /// — exactly the same behavior as before this interface existed.
+    /// </summary>
+    public interface IMonoWebhookConsumerExtensions
+    {
+        Task HandleMandateDebitSuccessfulEvent(MandateDebitEventModel webhook);
+        Task HandleMandateDebitFailedEvent(MandateDebitEventModel webhook);
+        Task HandleAccountIncomeEvent(AccountIncomeEventModel webhook);
+        Task HandleCreditworthinessEvent(CreditworthinessEventModel webhook);
+        Task HandleDisbursementEvent(DisbursementEventModel webhook);
+        Task HandleWatchlistMatchEvent(WatchlistMatchEventModel webhook);
+        Task HandleProveCompletedEvent(ProveEventModel webhook);
+        Task HandleProveFailedEvent(ProveEventModel webhook);
     }
 }

--- a/Mono.Core/Services/WebHookService/Models/MonoWebhookModel.cs
+++ b/Mono.Core/Services/WebHookService/Models/MonoWebhookModel.cs
@@ -109,8 +109,22 @@ namespace Mono.Core.Webhooks
     {
         [JsonPropertyName("event")]
         public string Event { get; set; }
+
         [JsonPropertyName("Data")]
         public T Data { get; set; }
+
+        /// <summary>Stable per-event identifier; safe to use for idempotency keys.</summary>
+        [JsonPropertyName("event_id")]
+        public string EventId { get; set; }
+
+        [JsonPropertyName("timestamp")]
+        public DateTime? Timestamp { get; set; }
+
+        [JsonPropertyName("app")]
+        public string App { get; set; }
+
+        [JsonPropertyName("business")]
+        public string Business { get; set; }
     }
 
     public class AccountConnectedEventModel
@@ -121,16 +135,45 @@ namespace Mono.Core.Webhooks
         public string Customer { get; set; }
     }
 
+    /// <summary>
+    /// Event-type constants. Each value is the full event string Mono sends
+    /// minus the <c>mono.events.</c> prefix — e.g. <c>account_connected</c>
+    /// or <c>mandate.debit.successful</c>.
+    /// </summary>
     public class MonoEventTypes
     {
         public const string WebhookTestEvent = "webhook_test";
+
+        // Connect / accounts
         public const string AccountConnected = "account_connected";
         public const string AccountUpdated = "account_updated";
-        public const string Unknown = "unknown";
-        public const string MandateCreated = "created";
-        public const string MandateReady = "ready";
-        public const string MandateApproved = "approved";
+        public const string AccountIncome = "account_income";
+        public const string Creditworthiness = "account_creditworthiness";
 
+        // Direct debit / mandates (fixed in v1.7.0 — previous values
+        // "created"/"ready"/"approved" were never matched by the controller
+        // routing because the event string is "mono.events.mandate.created").
+        public const string MandateCreated = "mandate.created";
+        public const string MandateApproved = "mandate.approved";
+        public const string MandateReady = "mandate.ready";
+        public const string MandateDebitSuccessful = "mandate.debit.successful";
+        public const string MandateDebitFailed = "mandate.debit.failed";
+
+        // Disburse (Sept 2025)
+        public const string DisbursementInitiated = "disbursement.initiated";
+        public const string DisbursementProcessing = "disbursement.processing";
+        public const string DisbursementCompleted = "disbursement.completed";
+        public const string DisbursementFailed = "disbursement.failed";
+
+        // Watchlist screening (March 2026)
+        public const string WatchlistMatchFound = "watchlist.match_found";
+        public const string WatchlistMonitoringUpdate = "watchlist.monitoring_update";
+
+        // Prove (KYC)
+        public const string ProveCompleted = "prove.completed";
+        public const string ProveFailed = "prove.failed";
+
+        public const string Unknown = "unknown";
     }
 
     public class MandateCreatedEventModel
@@ -336,5 +379,185 @@ namespace Mono.Core.Webhooks
 
         [JsonPropertyName("business")]
         public string Business { get; set; }
+    }
+
+    // ============ Events added in v1.7.0 ============
+
+    /// <summary>
+    /// Payload for <c>mono.events.mandate.debit.successful</c> and
+    /// <c>mono.events.mandate.debit.failed</c>.
+    /// </summary>
+    public class MandateDebitEventModel
+    {
+        [JsonPropertyName("id")]
+        public string Id { get; set; }
+
+        [JsonPropertyName("mandate")]
+        public string Mandate { get; set; }
+
+        [JsonPropertyName("reference")]
+        public string Reference { get; set; }
+
+        [JsonPropertyName("status")]
+        public string Status { get; set; }
+
+        [JsonPropertyName("amount")]
+        public long? Amount { get; set; }
+
+        [JsonPropertyName("currency")]
+        public string Currency { get; set; }
+
+        [JsonPropertyName("narration")]
+        public string Narration { get; set; }
+
+        [JsonPropertyName("nibss_code")]
+        public string NibssCode { get; set; }
+
+        [JsonPropertyName("failure_reason")]
+        public string FailureReason { get; set; }
+
+        [JsonPropertyName("processed_at")]
+        public DateTime? ProcessedAt { get; set; }
+
+        [JsonPropertyName("customer")]
+        public string Customer { get; set; }
+    }
+
+    /// <summary>Payload for <c>mono.events.account_income</c>.</summary>
+    public class AccountIncomeEventModel
+    {
+        [JsonPropertyName("account")]
+        public string Account { get; set; }
+
+        [JsonPropertyName("customer")]
+        public string Customer { get; set; }
+
+        [JsonPropertyName("currency")]
+        public string Currency { get; set; }
+
+        [JsonPropertyName("monthly_income")]
+        public double? MonthlyIncome { get; set; }
+
+        [JsonPropertyName("annual_income")]
+        public double? AnnualIncome { get; set; }
+
+        [JsonPropertyName("total_income")]
+        public double? TotalIncome { get; set; }
+
+        [JsonPropertyName("income_sources")]
+        public System.Collections.Generic.List<string> IncomeSources { get; set; }
+    }
+
+    /// <summary>Payload for <c>mono.events.account_creditworthiness</c>.</summary>
+    public class CreditworthinessEventModel
+    {
+        [JsonPropertyName("account")]
+        public string Account { get; set; }
+
+        [JsonPropertyName("customer")]
+        public string Customer { get; set; }
+
+        [JsonPropertyName("score")]
+        public double? Score { get; set; }
+
+        [JsonPropertyName("rating")]
+        public string Rating { get; set; }
+
+        [JsonPropertyName("recommendation")]
+        public string Recommendation { get; set; }
+    }
+
+    /// <summary>
+    /// Payload for any <c>mono.events.disbursement.*</c> event. Inspect
+    /// <see cref="Mono.Core.Webhooks.MonoWebhookModel{T}.Event"/> for the
+    /// specific lifecycle state (initiated / processing / completed / failed).
+    /// </summary>
+    public class DisbursementEventModel
+    {
+        [JsonPropertyName("id")]
+        public string Id { get; set; }
+
+        [JsonPropertyName("reference")]
+        public string Reference { get; set; }
+
+        [JsonPropertyName("source")]
+        public string Source { get; set; }
+
+        [JsonPropertyName("account")]
+        public string Account { get; set; }
+
+        [JsonPropertyName("type")]
+        public string Type { get; set; }
+
+        [JsonPropertyName("status")]
+        public string Status { get; set; }
+
+        [JsonPropertyName("total_amount")]
+        public long? TotalAmount { get; set; }
+
+        [JsonPropertyName("currency")]
+        public string Currency { get; set; }
+
+        [JsonPropertyName("distribution_count")]
+        public long? DistributionCount { get; set; }
+
+        [JsonPropertyName("processed_at")]
+        public DateTime? ProcessedAt { get; set; }
+
+        [JsonPropertyName("failure_reason")]
+        public string FailureReason { get; set; }
+    }
+
+    /// <summary>
+    /// Payload for <c>mono.events.watchlist.match_found</c> and
+    /// <c>mono.events.watchlist.monitoring_update</c>.
+    /// </summary>
+    public class WatchlistMatchEventModel
+    {
+        [JsonPropertyName("screening_id")]
+        public string ScreeningId { get; set; }
+
+        [JsonPropertyName("subject_name")]
+        public string SubjectName { get; set; }
+
+        [JsonPropertyName("subject_type")]
+        public string SubjectType { get; set; }
+
+        [JsonPropertyName("match_count")]
+        public int? MatchCount { get; set; }
+
+        [JsonPropertyName("risk_score")]
+        public double? RiskScore { get; set; }
+
+        [JsonPropertyName("risk_level")]
+        public string RiskLevel { get; set; }
+
+        [JsonPropertyName("monitoring")]
+        public bool? Monitoring { get; set; }
+    }
+
+    /// <summary>
+    /// Payload for <c>mono.events.prove.completed</c> and
+    /// <c>mono.events.prove.failed</c>.
+    /// </summary>
+    public class ProveEventModel
+    {
+        [JsonPropertyName("reference")]
+        public string Reference { get; set; }
+
+        [JsonPropertyName("session_id")]
+        public string SessionId { get; set; }
+
+        [JsonPropertyName("status")]
+        public string Status { get; set; }
+
+        [JsonPropertyName("kyc_level")]
+        public string KycLevel { get; set; }
+
+        [JsonPropertyName("customer")]
+        public string Customer { get; set; }
+
+        [JsonPropertyName("failure_reason")]
+        public string FailureReason { get; set; }
     }
 }

--- a/Mono.Core/Services/WebHookService/MonoWebhookController.cs
+++ b/Mono.Core/Services/WebHookService/MonoWebhookController.cs
@@ -1,10 +1,9 @@
-﻿using System;
-using System.IO;
-using System.Text;
+using System;
 using System.Text.Json;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Mono.Core.Webhooks;
 
 namespace Mono.Core.Webhooks
@@ -13,102 +12,219 @@ namespace Mono.Core.Webhooks
     [Route("api/[controller]")]
     public class MonoWebhookController : ControllerBase
     {
+        private const string SignatureHeader = "mono-webhook-secret";
+        private const string EventPrefix = "mono.events.";
+
         private readonly IMonoWebhookConsumer _webhookConsumer;
         private readonly ILogger<MonoWebhookController> _logger;
-        private string _eventType;
+        private readonly MonoInitializationOptions _options;
 
-        public MonoWebhookController(IMonoWebhookConsumer webhookConsumer, ILogger<MonoWebhookController> logger)
+        public MonoWebhookController(
+            IMonoWebhookConsumer webhookConsumer,
+            ILogger<MonoWebhookController> logger,
+            IOptions<MonoInitializationOptions> options)
         {
             _webhookConsumer = webhookConsumer;
             _logger = logger;
+            _options = options?.Value ?? new MonoInitializationOptions();
         }
 
         [HttpPost("receive", Name = nameof(ReceiveWebhookEvent))]
         public async Task<IActionResult> ReceiveWebhookEvent([FromBody] GenericWebHookModel payload)
         {
-            var serializedPayload = JsonSerializer.Serialize(payload);
-            Console.WriteLine("Webhook received");
-            Console.WriteLine($"Webhook data: {serializedPayload}");
-            Console.WriteLine($"Event type: {payload.Event}");
-            _eventType = payload.Event;
-            if (string.IsNullOrEmpty(serializedPayload)) return BadRequest();
-            var webhook = JsonSerializer.Deserialize<MonoWebhookModel<dynamic>>(serializedPayload);
+            if (!IsAuthenticated())
+            {
+                _logger.LogWarning("Rejected Mono webhook: mono-webhook-secret header missing or mismatched.");
+                return Unauthorized();
+            }
 
-            var eventType = GetEventType();
+            if (payload == null || string.IsNullOrEmpty(payload.Event))
+            {
+                return BadRequest();
+            }
+
+            var serializedPayload = JsonSerializer.Serialize(payload);
+            var eventType = ParseEventType(payload.Event);
+            _logger.LogInformation("Mono webhook received: event={Event} eventType={EventType}", payload.Event, eventType);
+
+            var extensions = _webhookConsumer as IMonoWebhookConsumerExtensions;
+
             switch (eventType)
             {
                 case MonoEventTypes.WebhookTestEvent:
-                    HandleTestEvent(webhook);
+                    _logger.LogInformation("Mono webhook test event received.");
                     break;
+
                 case MonoEventTypes.AccountConnected:
-                    Console.WriteLine($"Webhook data before it is parsed: {serializedPayload}");
-                    var accountConnectEvent = JsonSerializer.Deserialize<MonoWebhookModel<AccountConnectedEventModel>>(serializedPayload);
-                    Console.WriteLine($"Deserialized webhook data: {accountConnectEvent}");
-                    Console.WriteLine($"Deserialized webhook data: {JsonSerializer.Serialize(accountConnectEvent)}");
-                    await _webhookConsumer.HandleAccountCreatedEvent(accountConnectEvent.Data);
+                {
+                    var ev = JsonSerializer.Deserialize<MonoWebhookModel<AccountConnectedEventModel>>(serializedPayload);
+                    await _webhookConsumer.HandleAccountCreatedEvent(ev?.Data);
                     break;
+                }
+
                 case MonoEventTypes.AccountUpdated:
-                    var accountUpdatedEvent = JsonSerializer.Deserialize<MonoWebhookModel<AccountUpdatedEventModel>>(serializedPayload);
-                    await _webhookConsumer.HandleAccountUpdatedEvent(accountUpdatedEvent.Data);
+                {
+                    var ev = JsonSerializer.Deserialize<MonoWebhookModel<AccountUpdatedEventModel>>(serializedPayload);
+                    await _webhookConsumer.HandleAccountUpdatedEvent(ev?.Data);
                     break;
+                }
+
                 case MonoEventTypes.MandateCreated:
-                    var mandateCreatedEvent = JsonSerializer.Deserialize<MonoWebhookModel<MandateCreatedEventModel>>(serializedPayload);
-                    await _webhookConsumer.HandleMandateCreatedEvent(mandateCreatedEvent.Data);
+                {
+                    var ev = JsonSerializer.Deserialize<MonoWebhookModel<MandateCreatedEventModel>>(serializedPayload);
+                    await _webhookConsumer.HandleMandateCreatedEvent(ev?.Data);
                     break;
+                }
+
                 case MonoEventTypes.MandateApproved:
-                    var mandateApprovedEvent = JsonSerializer.Deserialize<MonoWebhookModel<MandateApprovedEventModel>>(serializedPayload);
-                    await _webhookConsumer.HandleMandateApprovedEvent(mandateApprovedEvent.Data);
+                {
+                    var ev = JsonSerializer.Deserialize<MonoWebhookModel<MandateApprovedEventModel>>(serializedPayload);
+                    await _webhookConsumer.HandleMandateApprovedEvent(ev?.Data);
                     break;
+                }
+
                 case MonoEventTypes.MandateReady:
-                    var mandateReadyEvent = JsonSerializer.Deserialize<MonoWebhookModel<MandateReadyEventModel>>(serializedPayload);
-                    await _webhookConsumer.HandleMandateReadyEvent(mandateReadyEvent.Data);
+                {
+                    var ev = JsonSerializer.Deserialize<MonoWebhookModel<MandateReadyEventModel>>(serializedPayload);
+                    await _webhookConsumer.HandleMandateReadyEvent(ev?.Data);
                     break;
+                }
+
+                case MonoEventTypes.MandateDebitSuccessful:
+                    await DispatchExtension(extensions, serializedPayload, (e, p) =>
+                    {
+                        var ev = JsonSerializer.Deserialize<MonoWebhookModel<MandateDebitEventModel>>(p);
+                        return e.HandleMandateDebitSuccessfulEvent(ev?.Data);
+                    });
+                    break;
+
+                case MonoEventTypes.MandateDebitFailed:
+                    await DispatchExtension(extensions, serializedPayload, (e, p) =>
+                    {
+                        var ev = JsonSerializer.Deserialize<MonoWebhookModel<MandateDebitEventModel>>(p);
+                        return e.HandleMandateDebitFailedEvent(ev?.Data);
+                    });
+                    break;
+
+                case MonoEventTypes.AccountIncome:
+                    await DispatchExtension(extensions, serializedPayload, (e, p) =>
+                    {
+                        var ev = JsonSerializer.Deserialize<MonoWebhookModel<AccountIncomeEventModel>>(p);
+                        return e.HandleAccountIncomeEvent(ev?.Data);
+                    });
+                    break;
+
+                case MonoEventTypes.Creditworthiness:
+                    await DispatchExtension(extensions, serializedPayload, (e, p) =>
+                    {
+                        var ev = JsonSerializer.Deserialize<MonoWebhookModel<CreditworthinessEventModel>>(p);
+                        return e.HandleCreditworthinessEvent(ev?.Data);
+                    });
+                    break;
+
+                case MonoEventTypes.DisbursementInitiated:
+                case MonoEventTypes.DisbursementProcessing:
+                case MonoEventTypes.DisbursementCompleted:
+                case MonoEventTypes.DisbursementFailed:
+                    await DispatchExtension(extensions, serializedPayload, (e, p) =>
+                    {
+                        var ev = JsonSerializer.Deserialize<MonoWebhookModel<DisbursementEventModel>>(p);
+                        return e.HandleDisbursementEvent(ev?.Data);
+                    });
+                    break;
+
+                case MonoEventTypes.WatchlistMatchFound:
+                case MonoEventTypes.WatchlistMonitoringUpdate:
+                    await DispatchExtension(extensions, serializedPayload, (e, p) =>
+                    {
+                        var ev = JsonSerializer.Deserialize<MonoWebhookModel<WatchlistMatchEventModel>>(p);
+                        return e.HandleWatchlistMatchEvent(ev?.Data);
+                    });
+                    break;
+
+                case MonoEventTypes.ProveCompleted:
+                    await DispatchExtension(extensions, serializedPayload, (e, p) =>
+                    {
+                        var ev = JsonSerializer.Deserialize<MonoWebhookModel<ProveEventModel>>(p);
+                        return e.HandleProveCompletedEvent(ev?.Data);
+                    });
+                    break;
+
+                case MonoEventTypes.ProveFailed:
+                    await DispatchExtension(extensions, serializedPayload, (e, p) =>
+                    {
+                        var ev = JsonSerializer.Deserialize<MonoWebhookModel<ProveEventModel>>(p);
+                        return e.HandleProveFailedEvent(ev?.Data);
+                    });
+                    break;
+
                 default:
                     await _webhookConsumer.HandleUnknownEvent(serializedPayload);
                     break;
             }
+
             return Ok();
         }
 
-        private void HandleTestEvent(MonoWebhookModel<dynamic> webhook)
+        private bool IsAuthenticated()
         {
-            Console.WriteLine("Hurray! Webhook test event received");
-            Console.WriteLine($"Event type: {GetEventType()}");
-            Console.WriteLine($"Webhook data: {JsonSerializer.Serialize(webhook)}");
-            Console.WriteLine("Webhook test event received");
+            var configured = _options.WebhookSecret;
+            if (string.IsNullOrEmpty(configured))
+            {
+                _logger.LogWarning(
+                    "MonoInitializationOptions.WebhookSecret is not configured; webhook signature verification is disabled. " +
+                    "Set the WebhookSecret to enforce verification of the mono-webhook-secret header.");
+                return true;
+            }
+
+            if (!Request.Headers.TryGetValue(SignatureHeader, out var header))
+            {
+                return false;
+            }
+
+            return FixedTimeEquals(header.ToString(), configured);
         }
 
-        private string GetEventType()
+        /// <summary>
+        /// Strips the <c>mono.events.</c> prefix from the raw event string so the
+        /// remainder matches the <see cref="MonoEventTypes"/> constants.
+        /// </summary>
+        private static string ParseEventType(string raw)
         {
-            var checker = _eventType.Split('.')[2];
-            if (_eventType.Contains("mandate"))
+            if (string.IsNullOrEmpty(raw)) return MonoEventTypes.Unknown;
+            return raw.StartsWith(EventPrefix, StringComparison.Ordinal)
+                ? raw.Substring(EventPrefix.Length)
+                : raw;
+        }
+
+        private async Task DispatchExtension(
+            IMonoWebhookConsumerExtensions extensions,
+            string serializedPayload,
+            Func<IMonoWebhookConsumerExtensions, string, Task> handler)
+        {
+            if (extensions == null)
             {
-                switch (checker)
-                {
-                    case MonoEventTypes.WebhookTestEvent:
-                        return MonoEventTypes.WebhookTestEvent;
-                    case MonoEventTypes.MandateCreated:
-                        return MonoEventTypes.MandateCreated;
-                    case MonoEventTypes.MandateApproved:
-                        return MonoEventTypes.MandateApproved;
-                    case MonoEventTypes.MandateReady:
-                        return MonoEventTypes.MandateReady;
-                    default:
-                        return MonoEventTypes.Unknown;
-                }
+                await _webhookConsumer.HandleUnknownEvent(serializedPayload);
+                return;
             }
 
-            switch (checker)
+            await handler(extensions, serializedPayload);
+        }
+
+        /// <summary>
+        /// Constant-time string comparison. netstandard2.0 doesn't have
+        /// <c>CryptographicOperations.FixedTimeEquals</c>, so we roll our own.
+        /// </summary>
+        private static bool FixedTimeEquals(string a, string b)
+        {
+            if (a == null || b == null) return false;
+            if (a.Length != b.Length) return false;
+            int diff = 0;
+            for (int i = 0; i < a.Length; i++)
             {
-                case MonoEventTypes.WebhookTestEvent:
-                    return MonoEventTypes.WebhookTestEvent;
-                case MonoEventTypes.AccountConnected:
-                    return MonoEventTypes.AccountConnected;
-                case MonoEventTypes.AccountUpdated:
-                    return MonoEventTypes.AccountUpdated;
-                default:
-                    return MonoEventTypes.Unknown;
+                diff |= a[i] ^ b[i];
             }
+            return diff == 0;
         }
     }
 

--- a/Readme.md
+++ b/Readme.md
@@ -111,31 +111,50 @@ public class YourService
 
 ## Accepting webhooks from Mono
 
-To package includes a predefined controller that you can use to accept webhooks from Mono. To use the controller, add your webhook URL to the Mono dashboard and as follows:
+The package includes a predefined controller that you can use to accept webhooks from Mono. Add your webhook URL to the Mono dashboard:
 
 <https://yourdomain.com/api/MonoWebhook/receive>
 
-Then you need to create a class that inherits the IMonoWebhookHandler interface and implement all missing methods.
+### Signature verification
+
+Set `WebhookSecret` on `MonoInitializationOptions` to the same secret you configured on the Mono dashboard. The controller compares it (in constant time) against the `mono-webhook-secret` header on every inbound POST and returns **401 Unauthorized** on mismatch.
 
 ```csharp
+services.AddMono(options =>
+{
+    options.SecretKey = "your_secret_key";
+    options.WebhookSecret = "your_webhook_secret"; // strongly recommended
+});
+```
+
+If `WebhookSecret` is null or empty, the controller logs a warning and processes the request anyway — opt-in for backward compatibility, but you should set it in production.
+
+### Implementing a consumer
+
+Implement `IMonoWebhookConsumer` for the original event surface (account + mandate creation/approval/ready). Optionally also implement `IMonoWebhookConsumerExtensions` for the newer events (mandate debit success/failure, income, creditworthiness, disbursement, watchlist matches, prove verification). Events your consumer doesn't implement fall through to `HandleUnknownEvent(string json)`.
+
+```csharp
+using Mono.Core;
 using Mono.Core.Webhooks;
 
-public class YourMonoWebhookHandler : IMonoWebhookConsumer
+public class YourMonoWebhookHandler : IMonoWebhookConsumer, IMonoWebhookConsumerExtensions
 {
-    public async Task HandleAccountCreatedEvent(AccountConnectedEventModel webhook)
-    {
-        // Handle the webhook
-    }
+    public Task HandleAccountCreatedEvent(AccountConnectedEventModel webhook) => Task.CompletedTask;
+    public Task HandleAccountUpdatedEvent(AccountUpdatedEventModel webhook) => Task.CompletedTask;
+    public Task HandleMandateCreatedEvent(MandateCreatedEventModel webhook) => Task.CompletedTask;
+    public Task HandleMandateApprovedEvent(MandateApprovedEventModel webhook) => Task.CompletedTask;
+    public Task HandleMandateReadyEvent(MandateReadyEventModel webhook) => Task.CompletedTask;
+    public Task HandleUnknownEvent(string json) => Task.CompletedTask;
 
-    public async Task HandleAccountUpdatedEvent(AccountUpdatedEventModel webhook)
-    {
-        // Handle the webhook
-    }
-
-    public async Task HandleUnknownEvent(AccountDeletedEventModel webhook)
-    {
-        // Handle the webhook
-    }
+    // IMonoWebhookConsumerExtensions — opt in to any of these
+    public Task HandleMandateDebitSuccessfulEvent(MandateDebitEventModel webhook) => Task.CompletedTask;
+    public Task HandleMandateDebitFailedEvent(MandateDebitEventModel webhook) => Task.CompletedTask;
+    public Task HandleAccountIncomeEvent(AccountIncomeEventModel webhook) => Task.CompletedTask;
+    public Task HandleCreditworthinessEvent(CreditworthinessEventModel webhook) => Task.CompletedTask;
+    public Task HandleDisbursementEvent(DisbursementEventModel webhook) => Task.CompletedTask;
+    public Task HandleWatchlistMatchEvent(WatchlistMatchEventModel webhook) => Task.CompletedTask;
+    public Task HandleProveCompletedEvent(ProveEventModel webhook) => Task.CompletedTask;
+    public Task HandleProveFailedEvent(ProveEventModel webhook) => Task.CompletedTask;
 }
 ```
 
@@ -358,6 +377,39 @@ This interface provides miscellaneous methods for managing Mono.
 - `GetCacLookup` This method to retieve cac lookup information.
 - `GetCacCompany` This method is use to retrieve shareholder information of a company.
 - `UnLinkAccount` This method provide you with the option to unlink their financial account(s).
+
+## Changes in 1.7.0 (May 2026)
+
+Webhook hardening — signature verification, fixes a long-standing routing bug, adds the newer event surface.
+
+**Signature verification (security):**
+- New `MonoInitializationOptions.WebhookSecret` — when set, `MonoWebhookController` constant-time-compares the `mono-webhook-secret` header and returns 401 on mismatch
+- If unset, the controller logs a warning and processes the request anyway (opt-in to preserve backward compatibility; set it in production)
+
+**Routing fix:**
+- The controller's previous routing for mandate events was broken — it took `event.Split('.')[2]` (always `"mandate"` for mandate events) and compared against constants like `"created"`, so the switch never matched and every mandate webhook fell into `HandleUnknownEvent`. Routing now strips the `mono.events.` prefix and matches the full suffix.
+- Removed the mutable `_eventType` instance field on the controller; event type is passed as a local
+
+**`MonoEventTypes` constants — breaking value change for mandate events:**
+- `MandateCreated` was `"created"`, now `"mandate.created"`
+- `MandateReady` was `"ready"`, now `"mandate.ready"`
+- `MandateApproved` was `"approved"`, now `"mandate.approved"`
+- The old values never matched anything in the controller routing, so this is a bug fix; users who hardcoded the old values for their own routing will need to update.
+
+**New event types:**
+- `mandate.debit.successful` / `mandate.debit.failed`
+- `account_income`
+- `account_creditworthiness`
+- `disbursement.initiated` / `processing` / `completed` / `failed`
+- `watchlist.match_found` / `watchlist.monitoring_update`
+- `prove.completed` / `prove.failed`
+
+**New optional `IMonoWebhookConsumerExtensions` interface** — implement alongside `IMonoWebhookConsumer` to receive the new events as strongly-typed payloads. Consumers that don't implement it receive these events via `HandleUnknownEvent` (same behavior as before).
+
+**Standard event fields added to `MonoWebhookModel<T>`:**
+- `event_id` (idempotency key)
+- `timestamp`
+- `app`, `business`
 
 ## Changes in 1.6.0 (May 2026)
 


### PR DESCRIPTION
## Summary

Three things, only one of which is purely additive:

1. **Signature verification** — `mono-webhook-secret` is now checked (opt-in via `WebhookSecret` option)
2. **Routing bug fix** — mandate webhook events have never actually reached their handlers in this library; they all fell through to `HandleUnknownEvent`
3. **New event surface** — `mandate.debit.successful/failed`, `account_income`, `account_creditworthiness`, `disbursement.*`, `watchlist.*`, `prove.*` — via a new optional `IMonoWebhookConsumerExtensions` interface so existing consumers don't break

## 1. Signature verification (security)

The webhook endpoint currently accepts unauthenticated POSTs from anyone who knows the URL. With this PR, set `WebhookSecret` on `MonoInitializationOptions`:

```csharp
services.AddMono(options =>
{
    options.SecretKey = "your_api_secret";
    options.WebhookSecret = "your_webhook_secret"; // from Mono dashboard
});
```

The controller constant-time-compares this against the `mono-webhook-secret` header on every inbound POST and returns **401 Unauthorized** on mismatch.

**Backward compat:** If `WebhookSecret` is null/empty, the controller logs a warning and processes the request anyway. Opt-in to security. The warning is loud enough that operators should notice it in production logs.

netstandard2.0 doesn't have `CryptographicOperations.FixedTimeEquals`, so this PR ships a small constant-time comparison helper.

## 2. Routing bug fix

The controller's `GetEventType()` previously did:

```csharp
var checker = _eventType.Split('.')[2];   // for "mono.events.mandate.created" → "mandate"
switch (checker)
{
    case MonoEventTypes.MandateCreated: ...  // "created" — never matches "mandate"
}
```

For `mono.events.account_connected`, `[2]` is `account_connected` — matches. For `mono.events.mandate.created`, `[2]` is `mandate`, but the cases compare against `"created"`. Result: **every mandate webhook this library has ever received fell through to `HandleUnknownEvent`.**

Fixed by stripping the `mono.events.` prefix and matching the full suffix.

This means three `MonoEventTypes` constants change **value** (not name):

| Constant | Old value (broken) | New value |
|---|---|---|
| `MandateCreated` | `"created"` | `"mandate.created"` |
| `MandateReady` | `"ready"` | `"mandate.ready"` |
| `MandateApproved` | `"approved"` | `"mandate.approved"` |

Anyone who hardcoded the old string values in their own routing will need to update. Since the old values weren't reachable via the controller, this is a bug fix; pragmatically a breaking change for anyone using these constants outside the library.

Also removed the mutable `_eventType` instance field — event type is now passed as a local. ASP.NET creates controllers per-request so there was no actual race, but the design was fragile (would break under singleton registration).

## 3. New event types — optional `IMonoWebhookConsumerExtensions`

Added the events Mono shipped since this library was last touched:

| Event | Payload model |
|---|---|
| `mono.events.mandate.debit.successful` | `MandateDebitEventModel` |
| `mono.events.mandate.debit.failed` | `MandateDebitEventModel` |
| `mono.events.account_income` | `AccountIncomeEventModel` |
| `mono.events.account_creditworthiness` | `CreditworthinessEventModel` |
| `mono.events.disbursement.initiated`/`processing`/`completed`/`failed` | `DisbursementEventModel` |
| `mono.events.watchlist.match_found` / `monitoring_update` | `WatchlistMatchEventModel` |
| `mono.events.prove.completed` / `prove.failed` | `ProveEventModel` |

Adding them to `IMonoWebhookConsumer` directly would break every existing implementation. Instead, they live on a separate optional interface:

```csharp
public class YourConsumer : IMonoWebhookConsumer, IMonoWebhookConsumerExtensions
{
    // existing methods unchanged
    public Task HandleAccountCreatedEvent(...) => ...;

    // new — opt in to any subset
    public Task HandleMandateDebitSuccessfulEvent(MandateDebitEventModel webhook) => ...;
    public Task HandleWatchlistMatchEvent(WatchlistMatchEventModel webhook) => ...;
    // ...
}
```

The controller does an `as IMonoWebhookConsumerExtensions` cast at dispatch time. Consumers that don't implement it receive these events via `HandleUnknownEvent(string json)` — exactly the same behavior as before the interface existed.

## Standard payload fields

Added to `MonoWebhookModel<T>`:
- `event_id` — stable per-event identifier; safe to use for idempotency keys
- `timestamp`
- `app`, `business`

Already present on individual event models like `AccountUpdatedEventModel`; promoting them to the envelope means consumers can read them uniformly.

## Code-smell cleanup

- Removed `_eventType` mutable instance field on the controller
- `IsAuthenticated()` helper for signature check
- `ParseEventType()` helper for prefix stripping
- `DispatchExtension()` helper to handle the "consumer doesn't implement extensions" fallback uniformly

## Compat summary

- **Additive:** `WebhookSecret` option, `IMonoWebhookConsumerExtensions` interface, new event-payload models, new fields on `MonoWebhookModel<T>`
- **Breaking (but a bug fix):** `MandateCreated` / `MandateReady` / `MandateApproved` constant values changed from single-segment suffixes to full event paths. Users who relied on the old values for their own routing will need to update, but the old values were unreachable via this library's controller — so nobody could have been using them correctly with this controller anyway.
- **Source-compat:** existing `IMonoWebhookConsumer` implementations don't need to change. The constructor signature on `MonoWebhookController` adds a required `IOptions<MonoInitializationOptions>` parameter — DI users get it for free; tests need to pass it (test class updated).

Package version: 1.6.0 → 1.7.0.

## Test plan

- [x] `dotnet build` — 0 errors, 0 warnings
- [x] Existing webhook controller tests updated for the new constructor parameter
- [ ] Sandbox / staging smoke test before publishing:
  - [ ] POST with no `mono-webhook-secret` header → 401 when `WebhookSecret` is set; 200 (with warning log) when unset
  - [ ] POST with wrong `mono-webhook-secret` → 401
  - [ ] POST with matching `mono-webhook-secret` → 200, handler dispatched
  - [ ] Send a real mandate webhook from the Mono dashboard and confirm `HandleMandateCreatedEvent` is now actually invoked (the routing bug fix)
  - [ ] Send a disbursement / watchlist / prove webhook and confirm the relevant extension method fires when implemented, or `HandleUnknownEvent` fires when not
- [ ] Payload shape verification (Mono's docs only show the `account_updated` schema in detail):
  - [ ] `MandateDebitEventModel` field names — `nibss_code` vs `nibss_response_code`, `failure_reason` vs `error`
  - [ ] `AccountIncomeEventModel.IncomeSources` — list of strings vs list of objects
  - [ ] `CreditworthinessEventModel` field names
  - [ ] `DisbursementEventModel.Status` values for each lifecycle event
  - [ ] `WatchlistMatchEventModel` — `risk_level` and `monitoring` semantics
  - [ ] `ProveEventModel` failure payload shape

## Follow-up PRs still queued

- **CAC**: PSC, Profile, Status-Report (replaces deprecated change-of-name / previous-address)
- **DirectPay**: Refund, Payout (by status), Payout Transactions
- **Webhook signature for HMAC** if Mono adds it — current spec is plain string comparison; the helper here can be swapped easily

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Harden Mono webhook handling by adding optional signature verification, fixing mandate event routing, and extending support for newer webhook event types.

New Features:
- Add optional webhook signature verification based on a configurable WebhookSecret compared against the mono-webhook-secret header.
- Expose new webhook event types and payload models for mandate debit, account income, creditworthiness, disbursement, watchlist, and prove events via an optional IMonoWebhookConsumerExtensions interface.
- Promote standard event metadata fields (event_id, timestamp, app, business) onto the MonoWebhookModel<T> envelope for uniform access.

Bug Fixes:
- Correct mandate webhook routing by parsing the full event suffix (after mono.events.) so mandate events reach their typed handlers instead of falling through to HandleUnknownEvent.
- Adjust MonoEventTypes mandate constants to use full mandate.* event keys so they align with the controller routing.

Enhancements:
- Refine MonoWebhookController design by removing mutable event-type state, centralizing event parsing and extension dispatch, and adding a constant-time string comparison helper for older target frameworks.
- Improve webhook and versioning documentation with guidance on signature verification, consumer implementation patterns, and a 1.7.0 change log section.

Tests:
- Update webhook controller tests to account for the new MonoInitializationOptions dependency while keeping signature verification opt-in for existing tests.