### PR TITLE
Add CAC PSC, Profile, Status-Report endpoints (v1.8.0)

### DIFF
--- a/Mono.Core/Mono.Core.csproj
+++ b/Mono.Core/Mono.Core.csproj
@@ -5,7 +5,7 @@
 			Mono.Core
 		</PackageId>
 		<Version>
-			1.7.0
+			1.8.0
 		</Version>
 		<Authors>
 			Adelowomi

--- a/Mono.Core/Services/LookUp/Abstractions/ILookUpService.cs
+++ b/Mono.Core/Services/LookUp/Abstractions/ILookUpService.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.IO;
+using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using Refit;
@@ -50,6 +51,18 @@ namespace Mono.Core.LookUp
         // /lookup/cac/company/322175/directors
         [Get("/lookup/cac/company/{businessId}/directors")]
         Task<IApiResponse<MonoStandardResponse<List<OfficialDetails>>>> GetDirectors(string businessId, CancellationToken cancellationToken = default);
+
+        // /lookup/cac/company/{businessId}/psc — Persons with Significant Control
+        [Get("/lookup/cac/company/{businessId}/psc")]
+        Task<IApiResponse<MonoStandardResponse<List<CacPscEntry>>>> GetCacPsc(string businessId, CancellationToken cancellationToken = default);
+
+        // /lookup/cac/profile/{rcNumber} — aggregate company profile
+        [Get("/lookup/cac/profile/{rcNumber}")]
+        Task<IApiResponse<MonoStandardResponse<CacProfileResponse>>> GetCacProfile(string rcNumber, CancellationToken cancellationToken = default);
+
+        // /lookup/cac/company/{businessId}/status-report — binary PDF download
+        [Get("/lookup/cac/company/{businessId}/status-report")]
+        Task<HttpResponseMessage> GetCacStatusReport(string businessId, CancellationToken cancellationToken = default);
 
         #endregion
 

--- a/Mono.Core/Services/LookUp/Abstractions/IMonoLookUpService.cs
+++ b/Mono.Core/Services/LookUp/Abstractions/IMonoLookUpService.cs
@@ -159,5 +159,28 @@ namespace Mono.Core.LookUp
         /// the PDF is ready, then <c>completed</c> with a 7-day download URL.
         /// </summary>
         Task<MonoStandardResponse<NinPollJobResponse>> PollNinJob(string jobId, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Lists the Persons with Significant Control for a company.
+        /// </summary>
+        /// <param name="businessId">The numeric CAC business id (from <see cref="GetCacLookUp"/>).</param>
+        Task<MonoStandardResponse<List<CacPscEntry>>> GetCacPsc(string businessId, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Aggregates business details, shareholders, directors, secretaries and
+        /// PSC for a company in a single call. Replaces the deprecated
+        /// <see cref="GetPreviousAddress"/> and <see cref="GetChangeOfName"/>
+        /// endpoints in many use cases.
+        /// </summary>
+        /// <param name="rcNumber">Company RC number (the registered company number, e.g. "RC123456") — not the numeric business id used by the other CAC endpoints.</param>
+        Task<MonoStandardResponse<CacProfileResponse>> GetCacProfile(string rcNumber, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Downloads a company's CAC status report as a PDF. Returns the raw
+        /// bytes in <see cref="MonoStandardResponse{T}.Data"/> on success;
+        /// the standard JSON error fields populate on failure.
+        /// </summary>
+        /// <param name="businessId">The numeric CAC business id.</param>
+        Task<MonoStandardResponse<byte[]>> GetCacStatusReport(string businessId, CancellationToken cancellationToken = default);
     }
 }

--- a/Mono.Core/Services/LookUp/LookUpService.cs
+++ b/Mono.Core/Services/LookUp/LookUpService.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Collections.Generic;
+using System.Net.Http;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -144,6 +146,52 @@ namespace Mono.Core.LookUp
         {
             var response = await _lookUpServiceV3.PollNinJob(jobId, cancellationToken);
             return response.HandleResponse();
+        }
+
+        public async Task<MonoStandardResponse<List<CacPscEntry>>> GetCacPsc(string businessId, CancellationToken cancellationToken = default)
+        {
+            var response = await _lookUpServiceV3.GetCacPsc(businessId, cancellationToken);
+            return response.HandleResponse();
+        }
+
+        public async Task<MonoStandardResponse<CacProfileResponse>> GetCacProfile(string rcNumber, CancellationToken cancellationToken = default)
+        {
+            var response = await _lookUpServiceV3.GetCacProfile(rcNumber, cancellationToken);
+            return response.HandleResponse();
+        }
+
+        public async Task<MonoStandardResponse<byte[]>> GetCacStatusReport(string businessId, CancellationToken cancellationToken = default)
+        {
+            using (var response = await _lookUpServiceV3.GetCacStatusReport(businessId, cancellationToken))
+            {
+                if (response.IsSuccessStatusCode)
+                {
+                    var bytes = await response.Content.ReadAsByteArrayAsync().ConfigureAwait(false);
+                    var ok = MonoStandardResponse<byte[]>.Ok(bytes);
+                    ok.Status = ((int)response.StatusCode).ToString();
+                    return ok;
+                }
+
+                var errorJson = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+                try
+                {
+                    var parsed = JsonSerializer.Deserialize<MonoStandardResponse<byte[]>>(errorJson);
+                    if (parsed != null)
+                    {
+                        parsed.Success = false;
+                        return parsed;
+                    }
+                }
+                catch (JsonException)
+                {
+                    // fall through
+                }
+
+                return MonoStandardResponse<byte[]>.Error(
+                    string.IsNullOrEmpty(errorJson)
+                        ? $"CAC status report request failed with status {(int)response.StatusCode}"
+                        : errorJson);
+            }
         }
 
     }

--- a/Mono.Core/Services/LookUp/Models/CacLookUpModels.cs
+++ b/Mono.Core/Services/LookUp/Models/CacLookUpModels.cs
@@ -1038,6 +1038,83 @@ namespace Mono.Core.LookUp
         public Biometrics Biometrics { get; set; }
     }
 
+    // ============ CAC additions (v1.8.0) ============
 
+    /// <summary>
+    /// One Person with Significant Control entry returned by
+    /// <c>GET /v3/lookup/cac/company/{id}/psc</c>.
+    /// </summary>
+    public class CacPscEntry
+    {
+        [JsonPropertyName("id")]
+        public string Id { get; set; }
 
+        [JsonPropertyName("name")]
+        public string Name { get; set; }
+
+        [JsonPropertyName("firstname")]
+        public string FirstName { get; set; }
+
+        [JsonPropertyName("surname")]
+        public string Surname { get; set; }
+
+        [JsonPropertyName("other_name")]
+        public string OtherName { get; set; }
+
+        [JsonPropertyName("type")]
+        public string Type { get; set; }
+
+        [JsonPropertyName("nationality")]
+        public string Nationality { get; set; }
+
+        [JsonPropertyName("date_of_birth")]
+        public DateTime? DateOfBirth { get; set; }
+
+        [JsonPropertyName("ownership_percentage")]
+        public double? OwnershipPercentage { get; set; }
+
+        [JsonPropertyName("voting_rights_percentage")]
+        public double? VotingRightsPercentage { get; set; }
+
+        [JsonPropertyName("nature_of_control")]
+        public List<string> NatureOfControl { get; set; }
+
+        [JsonPropertyName("date_of_appointment")]
+        public DateTime? DateOfAppointment { get; set; }
+
+        [JsonPropertyName("date_of_cessation")]
+        public DateTime? DateOfCessation { get; set; }
+
+        [JsonPropertyName("status")]
+        public string Status { get; set; }
+
+        [JsonPropertyName("address")]
+        public string Address { get; set; }
+
+        [JsonPropertyName("identity_number")]
+        public string IdentityNumber { get; set; }
+    }
+
+    /// <summary>
+    /// Aggregate CAC profile returned by <c>GET /v3/lookup/cac/profile/{rcNumber}</c>.
+    /// Bundles the business search summary, shareholders, directors,
+    /// secretaries, and persons with significant control in one call.
+    /// </summary>
+    public class CacProfileResponse
+    {
+        [JsonPropertyName("business")]
+        public BusinessDetails Business { get; set; }
+
+        [JsonPropertyName("shareholders")]
+        public List<OfficialDetails> Shareholders { get; set; }
+
+        [JsonPropertyName("directors")]
+        public List<OfficialDetails> Directors { get; set; }
+
+        [JsonPropertyName("secretaries")]
+        public List<OfficialDetails> Secretaries { get; set; }
+
+        [JsonPropertyName("psc")]
+        public List<CacPscEntry> Psc { get; set; }
+    }
 }

--- a/Readme.md
+++ b/Readme.md
@@ -297,6 +297,9 @@ This interface provides methods for looking up information in Mono.
 - `GetMashUp` This method allows you to verify the NIN, BVN and date of birth of your user in one API call for KYC.
 - `GetNinPdf` Submits a NIN lookup with `output=pdf`. Returns a job id; poll with `PollNinJob`.
 - `PollNinJob` Polls a NIN PDF generation job. Returns `processing` until ready, then `completed` with a 7-day-expiry download URL.
+- `GetCacPsc` Lists the Persons with Significant Control for a company.
+- `GetCacProfile` Aggregate company profile (business details, shareholders, directors, secretaries, PSC) by RC number — the supported replacement for the deprecated `GetPreviousAddress` / `GetChangeOfName`.
+- `GetCacStatusReport` Downloads a company's CAC status report as a PDF (raw bytes in `Data`).
 
 ### IMonoProve
 
@@ -377,6 +380,19 @@ This interface provides miscellaneous methods for managing Mono.
 - `GetCacLookup` This method to retieve cac lookup information.
 - `GetCacCompany` This method is use to retrieve shareholder information of a company.
 - `UnLinkAccount` This method provide you with the option to unlink their financial account(s).
+
+## Changes in 1.8.0 (May 2026)
+
+CAC additions — fills the gap left by the v1.1.0 deprecations of `GetPreviousAddress` / `GetChangeOfName`.
+
+**`IMonoLookUp`:**
+- `GetCacPsc` (GET `/lookup/cac/company/{id}/psc`) — Persons with Significant Control
+- `GetCacProfile` (GET `/lookup/cac/profile/{rcNumber}`) — aggregate profile (business + shareholders + directors + secretaries + PSC). Takes **RC number**, not the numeric business id used by the other CAC endpoints.
+- `GetCacStatusReport` (GET `/lookup/cac/company/{id}/status-report`) — binary PDF, returned as `byte[]`
+
+**Models added:**
+- `CacPscEntry` — name, ownership percentage, voting rights, nature of control, appointment/cessation dates
+- `CacProfileResponse` — aggregates `BusinessDetails`, `OfficialDetails` lists for shareholders/directors/secretaries, and `CacPscEntry` list
 
 ## Changes in 1.7.0 (May 2026)
 


### PR DESCRIPTION
## Summary

Fills the gap left when v1.1.0 marked `GetPreviousAddress` and `GetChangeOfName` `[Obsolete]` — Mono's stated replacement is the **CAC Profile** endpoint, which we now expose, alongside **PSC** (Persons with Significant Control) and the **Status Report** PDF.

## New surface on `IMonoLookUp` (3 endpoints, all v3)

| Method | Endpoint | Notes |
|---|---|---|
| `GetCacPsc` | GET `/lookup/cac/company/{businessId}/psc` | Returns `List<CacPscEntry>` |
| `GetCacProfile` | GET `/lookup/cac/profile/{rcNumber}` | Aggregate; takes **rc_number**, not the numeric `businessId` used by the other CAC endpoints |
| `GetCacStatusReport` | GET `/lookup/cac/company/{businessId}/status-report` | **Binary PDF**, returned as `byte[]` |

### Sample flow

```csharp
// 1. Find the business
var search = await _lookup.GetCacLookUp("acme limited");
var business = search.Data.First();

// 2. Full profile in one call (business + shareholders + directors + secretaries + PSC)
var profile = await _lookup.GetCacProfile(business.RcNumber);

// 3. PSC list
var psc = await _lookup.GetCacPsc(business.Id.ToString());
foreach (var person in psc.Data)
{
    Console.WriteLine($"{person.Name}: {person.OwnershipPercentage}% ownership");
}

// 4. Download the compliance PDF
var report = await _lookup.GetCacStatusReport(business.Id.ToString());
if (report.Success) await File.WriteAllBytesAsync("cac-report.pdf", report.Data);
```

## Path parameter wrinkle

`GetCacProfile` takes the **RC number** (e.g. `"RC123456"`) while every other CAC endpoint takes the **numeric business id** Mono returned from the search. This is Mono's design, not ours — flagged in the XML doc so consumers don't get tripped up.

## New models

- `CacPscEntry` — name, type, nationality, dob, ownership %, voting rights %, nature_of_control list, appointment/cessation dates, status, address, identity number
- `CacProfileResponse` — aggregate wrapping `BusinessDetails` + `List<OfficialDetails>` (shareholders / directors / secretaries) + `List<CacPscEntry>`

## PDF download handling

Same pattern used in `IMonoWatchlist.GetScreeningReport`: Refit method returns `HttpResponseMessage`; high-level reads bytes on 2xx, parses Mono's JSON error envelope on non-2xx, falls back to a generic error if the body isn't JSON. Consumers get the standard `MonoStandardResponse<byte[]>` shape either way.

## What's NOT included

- **Shareholder Details** — already exposed in the library as `GetCacCompany` (path `/lookup/cac/company/{id}` returns `List<OfficialDetails>`, which is the shareholder shape). No new method needed.

## Compat

- Pure additive — every change is a new method or a new model. No existing call site needs to change.
- Package version: 1.7.0 → 1.8.0

## Test plan

- [x] `dotnet build` — 0 errors, 0 warnings
- [ ] Sandbox smoke-test before NuGet publish:
  - [ ] Search a business, grab `id` + `rc_number`
  - [ ] `GetCacPsc(id)` returns at least one entry with `ownership_percentage` populated
  - [ ] `GetCacProfile(rcNumber)` returns the aggregate with all four sub-lists
  - [ ] `GetCacStatusReport(id)` returns bytes starting with `%PDF-`
- [ ] Field-name verification (Mono's public docs didn't expose full 200 schemas):
  - [ ] `CacPscEntry` — `ownership_percentage` vs `ownership` vs `share_percentage`
  - [ ] `CacPscEntry.NatureOfControl` — `List<string>` vs `List<object>` (depends on whether each entry is a code or a structured record)
  - [ ] `CacProfileResponse` wrapper keys — `business`/`shareholders`/`directors`/`secretaries`/`psc` (assumed flat; might be nested under `data` or `company`)

## Follow-up PRs still queued

- **DirectPay**: Refund, Payout (by status), Payout Transactions
- **Possible cleanup**: the 50/59 pre-existing test failures from the original audit — mocked `IRefitClientBuilder<T>` setups don't return the inner service. Separate scope, but it would be nice to actually have a working test suite before NuGet-publishing all this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add new CAC lookup capabilities for persons with significant control, aggregate company profiles, and status report PDFs via the Mono lookup client.

New Features:
- Expose GetCacPsc on IMonoLookUp to retrieve persons with significant control for a CAC company.
- Expose GetCacProfile on IMonoLookUp to fetch an aggregate CAC company profile including business details, shareholders, directors, secretaries, and PSC data by RC number.
- Expose GetCacStatusReport on IMonoLookUp to download a CAC company status report as a PDF with standardized response handling.

Enhancements:
- Introduce CacPscEntry and CacProfileResponse models to represent CAC PSC records and aggregate profiles in the lookup domain models.
- Document the new CAC endpoints and models in the README, including a 1.8.0 changelog entry describing the additions.

Documentation:
- Update README to describe new CAC PSC, profile, and status report lookup methods and note behavior changes for version 1.8.0.