### PR TITLE
Add DirectPay money-operations endpoints: Refund, Payouts, Sub-Accounts (v1.9.0)

### DIFF
--- a/Mono.Core/Mono.Core.csproj
+++ b/Mono.Core/Mono.Core.csproj
@@ -5,7 +5,7 @@
 			Mono.Core
 		</PackageId>
 		<Version>
-			1.8.0
+			1.9.0
 		</Version>
 		<Authors>
 			Adelowomi

--- a/Mono.Core/Services/DirectPay/Abstractions/IDirectPayService.cs
+++ b/Mono.Core/Services/DirectPay/Abstractions/IDirectPayService.cs
@@ -71,5 +71,26 @@ namespace Mono.Core.DirectPay
         [Post("/payments/mandates")]
         Task<IApiResponse<MonoStandardResponse<TokenizedMandateResponse>>> CreateMandate(CreateMandateModel createMandateModel, CancellationToken cancellationToken = default);
 
+        // -------- v1.9.0: money-operations --------
+
+        // /payments/refund
+        [Post("/payments/refund")]
+        Task<IApiResponse<MonoStandardResponse<RefundPaymentResponse>>> RefundPayment([Body] RefundPaymentModel model, CancellationToken cancellationToken = default);
+
+        // /payments/payouts — list payouts by status
+        [Get("/payments/payouts")]
+        Task<IApiResponse<MonoStandardResponse<PayoutListResponse>>> GetPayouts([Query] PayoutListQueryOptions options, CancellationToken cancellationToken = default);
+
+        // /payments/payout/{payoutId}/transactions
+        [Get("/payments/payout/{payoutId}/transactions")]
+        Task<IApiResponse<MonoStandardResponse<PayoutTransactionsResponse>>> GetPayoutTransactions(string payoutId, [Query] PayoutTransactionsQueryOptions options, CancellationToken cancellationToken = default);
+
+        // /payments/payout/sub-accounts
+        [Post("/payments/payout/sub-accounts")]
+        Task<IApiResponse<MonoStandardResponse<SubAccountResponse>>> CreateSubAccount([Body] CreateSubAccountModel model, CancellationToken cancellationToken = default);
+
+        // /payments/payout/sub-accounts
+        [Get("/payments/payout/sub-accounts")]
+        Task<IApiResponse<MonoStandardResponse<SubAccountListResponse>>> GetSubAccounts([Query] SubAccountListQueryOptions options, CancellationToken cancellationToken = default);
     }
 }

--- a/Mono.Core/Services/DirectPay/Abstractions/IMonoDirectPay.cs
+++ b/Mono.Core/Services/DirectPay/Abstractions/IMonoDirectPay.cs
@@ -133,5 +133,47 @@ namespace Mono.Core.DirectPay
         /// <param name="cancellationToken">A Cancellation token that can be used to cancel the task. This will terminate the HTTP request if triggered.</param>
         /// <returns>A synchronous task that returns a MonoStandardResponse and a TokenizedMandateResponse.</returns>
         Task<MonoStandardResponse<TokenizedMandateResponse>> CreateMandate(CreateMandateModel createMandateModel, CancellationToken cancellationToken = default);
+
+        // -------- v1.9.0: money operations --------
+
+        /// <summary>
+        /// Refunds a previously settled or pending payment by reference. The refund
+        /// is funded from the pending payout by default, or from your dashboard
+        /// wallet if <see cref="RefundPaymentModel.Source"/> is <c>"wallet"</c>.
+        /// </summary>
+        Task<MonoStandardResponse<RefundPaymentResponse>> RefundPayment(
+            RefundPaymentModel model,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Lists payouts. Filter by lifecycle status with
+        /// <see cref="PayoutListQueryOptions.Status"/>
+        /// (one of <see cref="PayoutStatusConstants"/>).
+        /// </summary>
+        Task<MonoStandardResponse<PayoutListResponse>> GetPayouts(
+            PayoutListQueryOptions options = null,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Lists the individual transactions that make up a single payout.
+        /// </summary>
+        Task<MonoStandardResponse<PayoutTransactionsResponse>> GetPayoutTransactions(
+            string payoutId,
+            PayoutTransactionsQueryOptions options = null,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Creates a sub-account used by split-payment configurations.
+        /// </summary>
+        Task<MonoStandardResponse<SubAccountResponse>> CreateSubAccount(
+            CreateSubAccountModel model,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Lists every sub-account created for split payments.
+        /// </summary>
+        Task<MonoStandardResponse<SubAccountListResponse>> GetSubAccounts(
+            SubAccountListQueryOptions options = null,
+            CancellationToken cancellationToken = default);
     }
 }

--- a/Mono.Core/Services/DirectPay/DirectPayService.cs
+++ b/Mono.Core/Services/DirectPay/DirectPayService.cs
@@ -107,5 +107,48 @@ namespace Mono.Core.DirectPay
             var response = await _directPayServiceV3.CreateMandate(createMandateModel, cancellationToken);
             return response.HandleResponse();
         }
+
+        // -------- v1.9.0: money operations --------
+
+        public async Task<MonoStandardResponse<RefundPaymentResponse>> RefundPayment(
+            RefundPaymentModel model,
+            CancellationToken cancellationToken = default)
+        {
+            var response = await _directPayService.RefundPayment(model, cancellationToken);
+            return response.HandleResponse();
+        }
+
+        public async Task<MonoStandardResponse<PayoutListResponse>> GetPayouts(
+            PayoutListQueryOptions options = null,
+            CancellationToken cancellationToken = default)
+        {
+            var response = await _directPayService.GetPayouts(options ?? new PayoutListQueryOptions(), cancellationToken);
+            return response.HandleResponse();
+        }
+
+        public async Task<MonoStandardResponse<PayoutTransactionsResponse>> GetPayoutTransactions(
+            string payoutId,
+            PayoutTransactionsQueryOptions options = null,
+            CancellationToken cancellationToken = default)
+        {
+            var response = await _directPayService.GetPayoutTransactions(payoutId, options ?? new PayoutTransactionsQueryOptions(), cancellationToken);
+            return response.HandleResponse();
+        }
+
+        public async Task<MonoStandardResponse<SubAccountResponse>> CreateSubAccount(
+            CreateSubAccountModel model,
+            CancellationToken cancellationToken = default)
+        {
+            var response = await _directPayService.CreateSubAccount(model, cancellationToken);
+            return response.HandleResponse();
+        }
+
+        public async Task<MonoStandardResponse<SubAccountListResponse>> GetSubAccounts(
+            SubAccountListQueryOptions options = null,
+            CancellationToken cancellationToken = default)
+        {
+            var response = await _directPayService.GetSubAccounts(options ?? new SubAccountListQueryOptions(), cancellationToken);
+            return response.HandleResponse();
+        }
     }
 }

--- a/Mono.Core/Services/DirectPay/Models/PayoutModels.cs
+++ b/Mono.Core/Services/DirectPay/Models/PayoutModels.cs
@@ -1,0 +1,154 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace Mono.Core.Services.DirectPay.Models
+{
+    public class PayoutListQueryOptions
+    {
+        /// <summary>One of <see cref="PayoutStatusConstants"/>.</summary>
+        [JsonPropertyName("status")]
+        public string Status { get; set; }
+
+        [JsonPropertyName("page")]
+        public int? Page { get; set; }
+
+        [JsonPropertyName("limit")]
+        public int? Limit { get; set; }
+
+        [JsonPropertyName("start")]
+        public string Start { get; set; }
+
+        [JsonPropertyName("end")]
+        public string End { get; set; }
+    }
+
+    public class PayoutResponse
+    {
+        [JsonPropertyName("id")]
+        public string Id { get; set; }
+
+        [JsonPropertyName("reference")]
+        public string Reference { get; set; }
+
+        [JsonPropertyName("status")]
+        public string Status { get; set; }
+
+        /// <summary>Amount in minor units (kobo for NGN, pesewa for GHS, cents for KES/ZAR).</summary>
+        [JsonPropertyName("amount")]
+        public long? Amount { get; set; }
+
+        [JsonPropertyName("currency")]
+        public string Currency { get; set; }
+
+        [JsonPropertyName("description")]
+        public string Description { get; set; }
+
+        [JsonPropertyName("settlement_account")]
+        public string SettlementAccount { get; set; }
+
+        [JsonPropertyName("settled_at")]
+        public DateTime? SettledAt { get; set; }
+
+        [JsonPropertyName("created_at")]
+        public DateTime? CreatedAt { get; set; }
+
+        [JsonPropertyName("updated_at")]
+        public DateTime? UpdatedAt { get; set; }
+    }
+
+    public class PayoutListResponse
+    {
+        [JsonPropertyName("payouts")]
+        public List<PayoutResponse> Payouts { get; set; }
+
+        [JsonPropertyName("meta")]
+        public PayoutPaginationMeta Meta { get; set; }
+    }
+
+    public class PayoutTransactionsQueryOptions
+    {
+        [JsonPropertyName("page")]
+        public int? Page { get; set; }
+
+        [JsonPropertyName("limit")]
+        public int? Limit { get; set; }
+
+        [JsonPropertyName("status")]
+        public string Status { get; set; }
+
+        [JsonPropertyName("start")]
+        public string Start { get; set; }
+
+        [JsonPropertyName("end")]
+        public string End { get; set; }
+    }
+
+    public class PayoutTransaction
+    {
+        [JsonPropertyName("id")]
+        public string Id { get; set; }
+
+        [JsonPropertyName("reference")]
+        public string Reference { get; set; }
+
+        [JsonPropertyName("payout")]
+        public string Payout { get; set; }
+
+        [JsonPropertyName("type")]
+        public string Type { get; set; }
+
+        [JsonPropertyName("amount")]
+        public long? Amount { get; set; }
+
+        [JsonPropertyName("currency")]
+        public string Currency { get; set; }
+
+        [JsonPropertyName("status")]
+        public string Status { get; set; }
+
+        [JsonPropertyName("narration")]
+        public string Narration { get; set; }
+
+        [JsonPropertyName("customer")]
+        public string Customer { get; set; }
+
+        [JsonPropertyName("created_at")]
+        public DateTime? CreatedAt { get; set; }
+
+        [JsonPropertyName("updated_at")]
+        public DateTime? UpdatedAt { get; set; }
+    }
+
+    public class PayoutTransactionsResponse
+    {
+        [JsonPropertyName("transactions")]
+        public List<PayoutTransaction> Transactions { get; set; }
+
+        [JsonPropertyName("meta")]
+        public PayoutPaginationMeta Meta { get; set; }
+    }
+
+    public class PayoutPaginationMeta
+    {
+        [JsonPropertyName("total")]
+        public long Total { get; set; }
+
+        [JsonPropertyName("page")]
+        public long Page { get; set; }
+
+        [JsonPropertyName("previous")]
+        public string Previous { get; set; }
+
+        [JsonPropertyName("next")]
+        public string Next { get; set; }
+    }
+
+    public class PayoutStatusConstants
+    {
+        public const string Pending = "pending";
+        public const string Processing = "processing";
+        public const string Settled = "settled";
+        public const string Failed = "failed";
+    }
+}

--- a/Mono.Core/Services/DirectPay/Models/RefundPaymentModel.cs
+++ b/Mono.Core/Services/DirectPay/Models/RefundPaymentModel.cs
@@ -1,0 +1,48 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
+
+namespace Mono.Core.Services.DirectPay.Models
+{
+    public class RefundPaymentModel
+    {
+        /// <summary>Reference of the original payment to refund.</summary>
+        [Required]
+        [JsonPropertyName("reference")]
+        public string Reference { get; set; }
+
+        /// <summary>"wallet" or "pending_payout" (default if omitted).</summary>
+        [JsonPropertyName("source")]
+        public string Source { get; set; }
+    }
+
+    public class RefundPaymentResponse
+    {
+        [JsonPropertyName("id")]
+        public string Id { get; set; }
+
+        [JsonPropertyName("reference")]
+        public string Reference { get; set; }
+
+        [JsonPropertyName("amount")]
+        public long? Amount { get; set; }
+
+        [JsonPropertyName("currency")]
+        public string Currency { get; set; }
+
+        [JsonPropertyName("source")]
+        public string Source { get; set; }
+
+        [JsonPropertyName("status")]
+        public string Status { get; set; }
+
+        [JsonPropertyName("created_at")]
+        public DateTime? CreatedAt { get; set; }
+    }
+
+    public class RefundSourceConstants
+    {
+        public const string Wallet = "wallet";
+        public const string PendingPayout = "pending_payout";
+    }
+}

--- a/Mono.Core/Services/DirectPay/Models/SubAccountModels.cs
+++ b/Mono.Core/Services/DirectPay/Models/SubAccountModels.cs
@@ -1,0 +1,81 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
+
+namespace Mono.Core.Services.DirectPay.Models
+{
+    public class CreateSubAccountModel
+    {
+        [Required]
+        [JsonPropertyName("name")]
+        public string Name { get; set; }
+
+        [Required]
+        [JsonPropertyName("account_number")]
+        public string AccountNumber { get; set; }
+
+        [Required]
+        [JsonPropertyName("bank_code")]
+        public string BankCode { get; set; }
+
+        /// <summary>NIP code of the destination bank.</summary>
+        [Required]
+        [JsonPropertyName("nip_code")]
+        public string NipCode { get; set; }
+    }
+
+    public class SubAccountResponse
+    {
+        [JsonPropertyName("id")]
+        public string Id { get; set; }
+
+        [JsonPropertyName("name")]
+        public string Name { get; set; }
+
+        [JsonPropertyName("account_number")]
+        public string AccountNumber { get; set; }
+
+        [JsonPropertyName("bank_code")]
+        public string BankCode { get; set; }
+
+        [JsonPropertyName("nip_code")]
+        public string NipCode { get; set; }
+
+        [JsonPropertyName("balance")]
+        public long? Balance { get; set; }
+
+        [JsonPropertyName("currency")]
+        public string Currency { get; set; }
+
+        [JsonPropertyName("status")]
+        public string Status { get; set; }
+
+        [JsonPropertyName("created_at")]
+        public DateTime? CreatedAt { get; set; }
+
+        [JsonPropertyName("updated_at")]
+        public DateTime? UpdatedAt { get; set; }
+    }
+
+    public class SubAccountListResponse
+    {
+        [JsonPropertyName("sub_accounts")]
+        public List<SubAccountResponse> SubAccounts { get; set; }
+
+        [JsonPropertyName("meta")]
+        public PayoutPaginationMeta Meta { get; set; }
+    }
+
+    public class SubAccountListQueryOptions
+    {
+        [JsonPropertyName("page")]
+        public int? Page { get; set; }
+
+        [JsonPropertyName("limit")]
+        public int? Limit { get; set; }
+
+        [JsonPropertyName("status")]
+        public string Status { get; set; }
+    }
+}

--- a/Readme.md
+++ b/Readme.md
@@ -223,6 +223,11 @@ This interface provides methods for managing direct pay in Mono.
 - `InitiatePayment` This method is use to initiate a one-time payment
 - `VerifyPayment` This method is use to Verify the payment using the reference passed when initiating payment.
 - `GetTransactions` This method is use to retrive payment transactions of a specific account.
+- `RefundPayment` Refunds a payment by reference. Funded from the pending payout by default, or from your wallet via `RefundSourceConstants.Wallet`.
+- `GetPayouts` Lists payouts. Filter by lifecycle status (`pending`/`processing`/`settled`/`failed`) via `PayoutStatusConstants`.
+- `GetPayoutTransactions` Lists the individual transactions inside a single payout.
+- `CreateSubAccount` Creates a sub-account used by split-payment configurations.
+- `GetSubAccounts` Lists every split-payment sub-account.
 
 ### IMonoDisburse
 
@@ -380,6 +385,23 @@ This interface provides miscellaneous methods for managing Mono.
 - `GetCacLookup` This method to retieve cac lookup information.
 - `GetCacCompany` This method is use to retrieve shareholder information of a company.
 - `UnLinkAccount` This method provide you with the option to unlink their financial account(s).
+
+## Changes in 1.9.0 (May 2026)
+
+DirectPay money-operations additions — fills the last gaps from the May 2026 doc audit.
+
+**`IMonoDirectPay` adds 5 endpoints (all v2):**
+- `RefundPayment` (POST `/payments/refund`) — body: `reference` + optional `source` (`wallet` or `pending_payout`)
+- `GetPayouts` (GET `/payments/payouts`) — list payouts; filter by `status` (`pending`/`processing`/`settled`/`failed`)
+- `GetPayoutTransactions` (GET `/payments/payout/{payoutId}/transactions`)
+- `CreateSubAccount` (POST `/payments/payout/sub-accounts`) — for split-payment configurations
+- `GetSubAccounts` (GET `/payments/payout/sub-accounts`)
+
+**Constants:**
+- `PayoutStatusConstants` (`pending` / `processing` / `settled` / `failed`)
+- `RefundSourceConstants` (`wallet` / `pending_payout`)
+
+**Path naming wrinkle:** Mono uses `payouts` (plural) for the list endpoint but `payout` (singular) for everything else. Mirrored verbatim in `[Get]`/`[Post]` attributes.
 
 ## Changes in 1.8.0 (May 2026)
 


### PR DESCRIPTION
## Summary

Closes the last gaps from the original May 2026 doc audit. The original audit listed Refund, Payout by status, and Payout Transactions; while spec'ing them I noticed two **sub-account** endpoints in the same money-operations section that complete the split-payment flow, so I bundled all five — they're a single coherent surface.

## New surface on `IMonoDirectPay` (5 endpoints, all v2)

| Method | Endpoint | Notes |
|---|---|---|
| `RefundPayment` | POST `/payments/refund` | Body: `reference` (required) + optional `source` (`wallet` \| `pending_payout`) |
| `GetPayouts` | GET `/payments/payouts` | List payouts; filter by `status` |
| `GetPayoutTransactions` | GET `/payments/payout/{payoutId}/transactions` | Transactions inside a single payout |
| `CreateSubAccount` | POST `/payments/payout/sub-accounts` | Split-payment sub-account |
| `GetSubAccounts` | GET `/payments/payout/sub-accounts` | List all sub-accounts |

### Path naming wrinkle

Mono uses **`payouts`** (plural) for the list endpoint and **`payout`** (singular) everywhere else. Not a typo on my end — mirrored verbatim from their docs.

## Constants

- `PayoutStatusConstants` — `pending` / `processing` / `settled` / `failed`
- `RefundSourceConstants` — `wallet` / `pending_payout`

## Models added

- `RefundPaymentModel`, `RefundPaymentResponse`
- `PayoutResponse`, `PayoutListResponse`, `PayoutListQueryOptions`
- `PayoutTransaction`, `PayoutTransactionsResponse`, `PayoutTransactionsQueryOptions`
- `PayoutPaginationMeta` (shared)
- `CreateSubAccountModel`, `SubAccountResponse`, `SubAccountListResponse`, `SubAccountListQueryOptions`

## Example

```csharp
// Refund a settled payment back to the customer
var refund = await _directpay.RefundPayment(new RefundPaymentModel
{
    Reference = "pay_abc123",
    // Source = RefundSourceConstants.Wallet,  // optional; defaults to pending_payout
});

// List failed payouts from the last 30 days
var failed = await _directpay.GetPayouts(new PayoutListQueryOptions
{
    Status = PayoutStatusConstants.Failed,
    Start = "2026-04-27",
    End = "2026-05-27",
});

// Set up a split-payment sub-account
var sub = await _directpay.CreateSubAccount(new CreateSubAccountModel
{
    Name = "Vendor payout",
    AccountNumber = "0123456789",
    BankCode = "044",
    NipCode = "000014",
});
```

## Compat

- Pure additive — every change is a new method or model. No existing call site needs to change.
- Reuses the existing `IRefitClientBuilder<IDirectPayService>.Build()` (v2) client that `DirectPayService` already has injected; no DI changes.
- Package version: 1.8.0 → 1.9.0

## Test plan

- [x] `dotnet build` — 0 errors, 0 warnings
- [ ] Sandbox smoke-test before NuGet publish:
  - [ ] `GetPayouts(status=settled)` returns settled payouts
  - [ ] `GetPayoutTransactions(payoutId)` returns the constituent transactions
  - [ ] `RefundPayment` against a known settled payment succeeds
  - [ ] `CreateSubAccount` + `GetSubAccounts` round-trip
- [ ] Field-name verification (Mono's docs didn't expose full 200 schemas):
  - [ ] `PayoutListResponse` wrapper key — `payouts[]` vs `data[]`
  - [ ] `SubAccountListResponse` wrapper key — `sub_accounts[]` vs `data[]`
  - [ ] `PayoutResponse.SettlementAccount` field name — `settlement_account` vs `account` vs `sub_account`
  - [ ] `RefundPaymentResponse` exact field set (id, reference, amount, status, source)

## What this completes

This was the last queued PR from the original May 2026 audit. Net result across the 11 PRs:

| Version | Surface |
|---|---|
| 1.1.0 | Drift fixes (BVN paths, lookup verbs, mandate v3, Refit CVE) |
| 1.2.0 | Customers API |
| 1.3.0 | Disburse API |
| 1.4.0 | Watchlist Screening |
| 1.5.0 | Prove (KYC) + `BuildV1()` |
| 1.6.0 | Real-time account balance, Account Match, NIN PDF + poll job |
| 1.7.0 | Webhook hardening (signature verification + routing bug fix + new event types) |
| 1.8.0 | CAC PSC / Profile / Status-Report |
| **1.9.0** | **DirectPay Refund / Payouts / Sub-Accounts** (this PR) |

Remaining cleanup (out of scope for this PR but worth flagging): the 50/59 pre-existing test failures noted in the original audit — mocked `IRefitClientBuilder<T>` setups don't return the inner service. Worth its own follow-up before NuGet-publishing all this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add DirectPay money-operations support and bump the library to version 1.9.0.

New Features:
- Expose refund, payout listing, payout transaction listing, and sub-account management methods on IMonoDirectPay and DirectPayService.
- Introduce request/response models, pagination metadata, and constants for refunds, payouts, payout transactions, and sub-accounts.

Build:
- Update the Mono.Core package version to 1.9.0.

Documentation:
- Document the new DirectPay money-operations methods and describe the 1.9.0 changes in the README.