### PR TITLE
fix(authorization): AuthorizeAccount endpoint is /accounts/auth (plural)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to **Mono.Core** are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project follows
 [Semantic Versioning](https://semver.org/).
 
+## [1.9.1] — 2026-05
+
+### Fixed
+
+- **`IMonoAuthorization.AuthorizeAccount` now POSTs to `/accounts/auth`
+  (plural).** The Refit attribute was `[Post("/account/auth")]` (singular),
+  which doesn't exist on Mono's API. Every link-exchange call surfaced as
+  HTTP 404 → consumers re-skinned it as "code expired", masking the real
+  cause. Every other route in the same interface used the plural form;
+  this was an isolated typo. No API surface change for consumers — calling
+  code stays identical.
+
 ## [1.9.0] — 2026-05
 
 DirectPay money-operations additions — closes the last gaps from the May 2026

--- a/Mono.Core/Mono.Core.csproj
+++ b/Mono.Core/Mono.Core.csproj
@@ -5,7 +5,7 @@
 
 		<!-- ==================== NuGet package metadata ==================== -->
 		<PackageId>Mono.Core</PackageId>
-		<Version>1.9.0</Version>
+		<Version>1.9.1</Version>
 		<Authors>Adelowomi</Authors>
 		<Company>Harmonics Technology</Company>
 		<Description>A .NET client library for the Mono API (https://mono.co): Connect (Accounts, Customers), DirectPay, Disburse, Lookup (BVN, NIN, CAC, TIN, watchlist screening), Prove KYC, plus a webhook controller with signature verification.</Description>

--- a/Mono.Core/Services/Authorization/Abstractions/IAuthorizationService.cs
+++ b/Mono.Core/Services/Authorization/Abstractions/IAuthorizationService.cs
@@ -11,8 +11,10 @@ namespace Mono.Core.Authorization
         [Post("/accounts/initiate")]
         Task<IApiResponse<MonoStandardResponse<AccountLinkingResponseModel>>> InitiateAccountLinking([Body] AccountLinkingModel accountLinkingModel, CancellationToken cancellationToken = default);
 
-        // account/auth
-        [Post("/account/auth")]
+        // accounts/auth — exchanges a Mono Connect code for a permanent account id.
+        // The path is plural; an earlier typo here ('/account/auth') caused every
+        // link-exchange to surface as MONO_LINK_EXPIRED because Mono returned 404.
+        [Post("/accounts/auth")]
         Task<IApiResponse<MonoStandardResponse<AuthorizationAccountResponseModel>>> AuthorizeAccount([Body] AuthorizationAccountRequestModel authorizationAccountRequestModel, CancellationToken cancellationToken = default);
 
         // accounts/{accountId}/sync


### PR DESCRIPTION
## Summary

- `IAuthorizationService.AuthorizeAccount` now POSTs to **`/accounts/auth`** (plural) instead of `/account/auth` (singular).
- Every other route in the same interface already used the plural form (`/accounts/initiate`, `/accounts/{id}/sync`, `/accounts/{id}/reauthorise`); this was an isolated typo from when the interface was first written.
- Version bump `1.9.0 → 1.9.1` (patch — no API contract change, only the wire URL is now correct).
- CHANGELOG entry under `[1.9.1]`.

## Why it matters

Pace API observed every successful Mono Connect linking returning **HTTP 400 `MONO_LINK_EXPIRED`** from `POST /api/v1/accounts/link-exchange`. Investigation traced this to Mono replying **404 Not Found** for `/account/auth` — a route that doesn't exist on Mono's API. Consumers typically re-skin a Mono 404 on auth as "code expired", which masked the real cause and made debugging painful.

After this fix, the Refit-generated URL is `https://api.withmono.com/v2/accounts/auth` (the documented Mono endpoint), and code exchange works.

## Test plan

- [x] `dotnet build -c Release` succeeds (warnings unchanged, no new errors)
- [ ] Consumer (pace-api) bumps Mono.Core to 1.9.1 after CI publishes
- [ ] Live test: open the Paces mobile link flow against a sandbox Mono account → expect `POST /accounts/link-exchange` → 201 (was 400 MONO_LINK_EXPIRED)

## Follow-up worth considering

A single contract test that asserts each `[Post(...)]` attribute resolves to the expected URL — see Refit's `RequestBuilder` / `IRequestBuilder` for the seam. Would have caught this at build time.

## Summary by Sourcery

Fix the account authorization endpoint path and bump the library patch version.

Bug Fixes:
- Correct the IAuthorizationService.AuthorizeAccount endpoint to post to /accounts/auth instead of the nonexistent /account/auth, restoring successful link-exchange flows.

Build:
- Bump the Mono.Core package version from 1.9.0 to 1.9.1.

Documentation:
- Document the 1.9.1 patch release and the authorization endpoint fix in the changelog.