### PR TITLE
fix(refit): HandleResponse no longer NREs on atypical Mono responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to **Mono.Core** are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project follows
 [Semantic Versioning](https://semver.org/).
 
+## [1.9.2] — 2026-05
+
+### Fixed
+
+- **`RefitExtensions.HandleResponse<T>` no longer throws `NullReferenceException`
+  on non-typical Mono responses.** Three latent null derefs:
+  - `response.Error.Content` could be null (empty body, proxy 5xx); now
+    guarded.
+  - `JsonSerializer.Deserialize<...>` can legitimately return null (e.g.
+    body is the literal string `"null"` or non-JSON); now caught and
+    surfaced as a typed `Error` envelope instead of NRE'ing.
+  - `response.Content` could be null on a `200 No Content`; now guarded
+    with an explicit "empty response body" error message.
+
+  Consumers always get a `MonoStandardResponse<T>` back. Any unparseable
+  error body now surfaces both the status code and (when present) the
+  parsed envelope's message, making upstream debugging cheaper.
+
 ## [1.9.1] — 2026-05
 
 ### Fixed

--- a/Mono.Core.Tests/Services/DirectPayService.cs
+++ b/Mono.Core.Tests/Services/DirectPayService.cs
@@ -54,8 +54,14 @@ namespace Mono.Core.DirectPay.Tests
             _mockDirectPayService.Setup(x => x.InitiatePayment(initiatePaymentRequestModel, It.IsAny<CancellationToken>()))
                                  .ReturnsAsync(errorResponse);
 
-            // Act & Assert
-            await Assert.ThrowsAsync <NullReferenceException>(() => _directPayService.InitiatePayment(initiatePaymentRequestModel));
+            // Act
+            var result = await _directPayService.InitiatePayment(initiatePaymentRequestModel);
+
+            // Assert — HandleResponse maps a non-success with no body into a
+            // typed Error envelope instead of throwing NRE (regression cover).
+            Assert.NotNull(result);
+            Assert.False(result.Success);
+            Assert.False(string.IsNullOrEmpty(result.Message));
             _mockDirectPayService.Verify(x => x.InitiatePayment(initiatePaymentRequestModel, It.IsAny<CancellationToken>()), Times.Once);
         }
 
@@ -85,8 +91,14 @@ namespace Mono.Core.DirectPay.Tests
             _mockDirectPayService.Setup(x => x.VerifyPayment(reference, It.IsAny<CancellationToken>()))
                                  .ReturnsAsync(errorResponse);
 
-            // Act & Assert
-            await Assert.ThrowsAsync<NullReferenceException>(() => _directPayService.VerifyPayment(reference));
+            // Act
+            var result = await _directPayService.VerifyPayment(reference);
+
+            // Assert — HandleResponse maps a non-success with no body into a
+            // typed Error envelope instead of throwing NRE (regression cover).
+            Assert.NotNull(result);
+            Assert.False(result.Success);
+            Assert.False(string.IsNullOrEmpty(result.Message));
             _mockDirectPayService.Verify(x => x.VerifyPayment(reference, It.IsAny<CancellationToken>()), Times.Once);
         }
 
@@ -116,8 +128,14 @@ namespace Mono.Core.DirectPay.Tests
             _mockDirectPayService.Setup(x => x.GetTransactions(options, It.IsAny<CancellationToken>()))
                                  .ReturnsAsync(errorResponse);
 
-            // Act & Assert
-            await Assert.ThrowsAsync<NullReferenceException>(() => _directPayService.GetTransactions(options));
+            // Act
+            var result = await _directPayService.GetTransactions(options);
+
+            // Assert — HandleResponse maps a non-success with no body into a
+            // typed Error envelope instead of throwing NRE (regression cover).
+            Assert.NotNull(result);
+            Assert.False(result.Success);
+            Assert.False(string.IsNullOrEmpty(result.Message));
             _mockDirectPayService.Verify(x => x.GetTransactions(options, It.IsAny<CancellationToken>()), Times.Once);
         }
     }

--- a/Mono.Core/Extensions/RefitExtensions.cs
+++ b/Mono.Core/Extensions/RefitExtensions.cs
@@ -6,22 +6,59 @@ namespace Mono.Core
 {
     public static class RefitExtensions
     {
+        /// <summary>
+        /// Maps a Refit <see cref="IApiResponse{T}"/> into our normalised
+        /// <see cref="MonoStandardResponse{T}"/> envelope. Tolerant of every
+        /// shape Mono can return — empty bodies, malformed error envelopes,
+        /// 5xx with no JSON, network failures — so consumers never see a
+        /// <see cref="NullReferenceException"/> bubble up from this layer.
+        /// </summary>
         public static MonoStandardResponse<T> HandleResponse<T>(this IApiResponse<MonoStandardResponse<T>> response)
         {
+            if (response == null)
+                return MonoStandardResponse<T>.Error("No response from Mono");
+
             if (!response.IsSuccessStatusCode)
             {
-                // deserialize error response and populate the response details
-                var JsonResponse = JsonSerializer.Deserialize<MonoStandardResponse<T>>(response.Error.Content);
-                return JsonResponse;
+                // Refit captures the body in response.Error.Content. It can be
+                // null when the server sent no body (e.g. 504 from a proxy) and
+                // it can be a non-JSON string (HTML error page from an upstream).
+                // Try to parse; on any failure fall through to a typed error
+                // envelope so the caller still gets a usable response.
+                var errorBody = response.Error?.Content;
+                if (!string.IsNullOrEmpty(errorBody))
+                {
+                    try
+                    {
+                        var parsed = JsonSerializer.Deserialize<MonoStandardResponse<T>>(errorBody);
+                        if (parsed != null)
+                        {
+                            parsed.Success = false;
+                            // Surface the raw body in Message when the parsed
+                            // envelope didn't include one — keeps debugging cheap.
+                            if (string.IsNullOrEmpty(parsed.Message))
+                                parsed.Message = $"{(int)response.StatusCode} {response.StatusCode}";
+                            return parsed;
+                        }
+                    }
+                    catch (JsonException)
+                    {
+                        // Body was non-JSON. Fall through.
+                    }
+                }
+
+                var message = response.Error?.Message
+                    ?? $"Mono returned {(int)response.StatusCode} {response.StatusCode} with no body";
+                return MonoStandardResponse<T>.Error(message);
             }
 
-            if (response.IsSuccessStatusCode)
-            {
-                response.Content.Success = true;
-                return response.Content;
-            }
+            // Success path — but the body can still be null if Mono returned
+            // 200 No Content or an empty JSON `null`. Refuse to NRE on .Content.
+            if (response.Content == null)
+                return MonoStandardResponse<T>.Error("Mono returned an empty response body");
 
-            return MonoStandardResponse<T>.Error(response.Content.Message);
+            response.Content.Success = true;
+            return response.Content;
         }
     }
 }

--- a/Mono.Core/Mono.Core.csproj
+++ b/Mono.Core/Mono.Core.csproj
@@ -5,7 +5,7 @@
 
 		<!-- ==================== NuGet package metadata ==================== -->
 		<PackageId>Mono.Core</PackageId>
-		<Version>1.9.1</Version>
+		<Version>1.9.2</Version>
 		<Authors>Adelowomi</Authors>
 		<Company>Harmonics Technology</Company>
 		<Description>A .NET client library for the Mono API (https://mono.co): Connect (Accounts, Customers), DirectPay, Disburse, Lookup (BVN, NIN, CAC, TIN, watchlist screening), Prove KYC, plus a webhook controller with signature verification.</Description>


### PR DESCRIPTION
## Summary

\`RefitExtensions.HandleResponse<T>\` had three null derefs that surfaced as \`NullReferenceException\` all the way up the stack into consumer code. The fix makes the mapper tolerant of every shape Mono can return.

The three latent bugs:

1. **\`response.Error.Content\`** — null when Refit captured a non-success status with no body (proxy 504, upstream 5xx, gateway timeouts). Now guarded.
2. **\`JsonSerializer.Deserialize<...>\`** — can legitimately return null (literal string \`\"null\"\`, non-JSON like an HTML 502 page). Now caught on \`JsonException\` and surfaced as a typed \`Error\` envelope.
3. **\`response.Content\`** — null on 200 No Content. The success path then did \`response.Content.Success = true\` and NRE'd. Now guarded with an \"empty response body\" error.

## Why this matters

Reported from prod: a Mono \`GetTransactions\` call hit a non-success with an unparseable body. The NRE bubbled to pace-api's global exception handler as \`500 SERVER_ERROR\`, **masking what Mono actually said**. With this fix the upstream HTTP status code + (when present) the parsed message round-trip back to the consumer so debugging stays cheap.

## Verification

- [x] \`dotnet build -c Release Mono.Core\`: 0 errors (pre-existing XML doc warnings unchanged)
- [ ] Consumer test (pace-api): bump to \`Mono.Core 1.9.2\`, redeploy, retry the call that previously NRE'd → expect a typed error envelope with the real Mono message instead of a stack trace.

## Version bump

\`1.9.1 → 1.9.2\` (patch — defensive only, no API surface change).

## Summary by Sourcery

Harden Refit response handling to always return a safe MonoStandardResponse wrapper instead of throwing on atypical HTTP responses.

Bug Fixes:
- Prevent NullReferenceException in HandleResponse when Refit provides null error content, null deserialization results, or null success content bodies.

Documentation:
- Document the new defensive behavior and edge cases for HandleResponse in the changelog, including the guarantee of always returning a MonoStandardResponse<T>.