### PR TITLE
fix(accounts): GetTransactions matches Mono's flat response shape

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,45 @@ All notable changes to **Mono.Core** are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project follows
 [Semantic Versioning](https://semver.org/).
 
+## [1.9.3] — 2026-05
+
+### Fixed
+
+- **`IMonoAccounts.GetTransactions` now correctly deserialises Mono's
+  flat transactions response.** Mono returns the endpoint as
+  `{ status, message, timestamp, data: [ ... ] }` — `data` is the
+  transaction array directly. The Refit signature previously expected
+  `MonoStandardResponse<TransactionResponseModel>` (data nested inside
+  an object with its own `paging` + `data` fields), so System.Text.Json
+  hit a type mismatch (`data: array → object`) and silently returned
+  `null` Content. After `1.9.2` made `HandleResponse` defensive this
+  surfaced as `"Mono returned an empty response body"` instead of a
+  `NullReferenceException`, but transactions still didn't flow through.
+
+  The Refit interface now declares
+  `MonoStandardResponse<List<Transaction>>`, matching the actual wire
+  shape. `AccountService.GetTransactions` adapts the deserialised
+  envelope back into `MonoStandardResponse<TransactionResponseModel>`
+  so existing consumers (e.g. `response.Data.Transactions`) keep
+  working unchanged.
+
+  `TransactionResponseModel.Paging` is now populated from Mono's
+  top-level `meta` field (verified against
+  [docs.mono.co/api/bank-data/transactions](https://docs.mono.co/api/bank-data/transactions)
+  and a live API capture). Mono returns `meta` in both `paginate=true`
+  and `paginate=false` modes; previously every consumer saw it as null
+  because the wrapper looked for a nested `paging` field that Mono
+  doesn't send.
+
+### Added
+
+- **`MonoStandardResponse<T>.Meta`** — top-level pagination envelope
+  (`total`, `page`, `previous`, `next`). Mono surfaces this consistently
+  across list endpoints (transactions, payouts, etc.); the envelope
+  type now captures it so the wire shape is honest. Backward-compatible:
+  consumers that didn't read pagination metadata don't notice the
+  addition.
+
 ## [1.9.2] — 2026-05
 
 ### Fixed

--- a/Mono.Core.Tests/Services/AccountServiceTwo.cs
+++ b/Mono.Core.Tests/Services/AccountServiceTwo.cs
@@ -248,29 +248,38 @@ public class AccountServiceTests
             Limit = 10
         };
 
-        var expectedResponse = new MonoStandardResponse<TransactionResponseModel>
+        // Refit deserialises into MonoStandardResponse<List<Transaction>> now
+        // (matching Mono's actual flat response shape). The public wrapper in
+        // AccountService.GetTransactions adapts it back into
+        // MonoStandardResponse<TransactionResponseModel>, so external
+        // assertions on response.Data.Transactions keep working.
+        var transactions = new List<Transaction>
         {
-            Data = new TransactionResponseModel
+            new Transaction
             {
-                Transactions = new List<Transaction>
-                {
-                    new Transaction
-                    {
-                        Id = "txn123",
-                        Type = "credit",
-                        Amount = 1000,
-                        Narration = "Salary",
-                        Date = DateTimeOffset.UtcNow,
-                        Balance = 2000
-                    }
-                },
-                Paging = new MonoStandardPaginatedResponse { }
-            },
-            Status = "success"
+                Id = "txn123",
+                Type = "credit",
+                Amount = 1000,
+                Narration = "Salary",
+                Date = DateTimeOffset.UtcNow,
+                Balance = 2000
+            }
+        };
+        var refitEnvelope = new MonoStandardResponse<List<Transaction>>
+        {
+            Data = transactions,
+            Status = "success",
+            Meta = new MonoStandardPaginatedResponse
+            {
+                Total = 307,
+                Page = 1,
+                Previous = null,
+                Next = "https://api.withmono.com/v2/abc/transactions?page=2"
+            }
         };
 
         _mockAccountService.Setup(x => x.GetTransactions(accountId, transactionsRequest, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new ApiResponse<MonoStandardResponse<TransactionResponseModel>>(new HttpResponseMessage(HttpStatusCode.OK), expectedResponse, new RefitSettings()));
+            .ReturnsAsync(new ApiResponse<MonoStandardResponse<List<Transaction>>>(new HttpResponseMessage(HttpStatusCode.OK), refitEnvelope, new RefitSettings()));
 
         // Act
         var response = await _accountService.GetTransactions(accountId, transactionsRequest);
@@ -278,6 +287,16 @@ public class AccountServiceTests
         // Assert
         Assert.NotNull(response);
         Assert.Equal("success", response.Status);
-        Assert.Equal(expectedResponse.Data.Transactions.Count, response.Data.Transactions.Count);
+        Assert.NotNull(response.Data);
+        Assert.Equal(transactions.Count, response.Data.Transactions.Count);
+        Assert.Equal("txn123", response.Data.Transactions[0].Id);
+        // Mono's `meta` envelope (top-level on the wire) should be surfaced
+        // through TransactionResponseModel.Paging so consumers get cursor
+        // + total without inspecting raw Refit responses.
+        Assert.NotNull(response.Data.Paging);
+        Assert.Equal(307, response.Data.Paging.Total);
+        Assert.Equal(1, response.Data.Paging.Page);
+        Assert.Null(response.Data.Paging.Previous);
+        Assert.Contains("page=2", response.Data.Paging.Next);
     }
 }

--- a/Mono.Core/Models/UtilityModels/MonoStandardResponse.cs
+++ b/Mono.Core/Models/UtilityModels/MonoStandardResponse.cs
@@ -14,6 +14,15 @@ namespace Mono.Core
         public string Status { get; set; }
         [JsonPropertyName("data")]
         public T Data { get; set; }
+        /// <summary>
+        /// Mono's pagination metadata. Present on list-style responses
+        /// (e.g. transactions, payouts) in both paginate=true and
+        /// paginate=false modes. <c>Total</c> is always populated;
+        /// <c>Previous</c>/<c>Next</c> are the cursor URLs and null at
+        /// the edges of the result set.
+        /// </summary>
+        [JsonPropertyName("meta")]
+        public MonoStandardPaginatedResponse Meta { get; set; }
         public Exception InAppErrors { get; set; }
         [JsonPropertyName("errors")]
         public MonoErrors[] MonoErrors { get; set; }

--- a/Mono.Core/Mono.Core.csproj
+++ b/Mono.Core/Mono.Core.csproj
@@ -5,7 +5,7 @@
 
 		<!-- ==================== NuGet package metadata ==================== -->
 		<PackageId>Mono.Core</PackageId>
-		<Version>1.9.2</Version>
+		<Version>1.9.3</Version>
 		<Authors>Adelowomi</Authors>
 		<Company>Harmonics Technology</Company>
 		<Description>A .NET client library for the Mono API (https://mono.co): Connect (Accounts, Customers), DirectPay, Disburse, Lookup (BVN, NIN, CAC, TIN, watchlist screening), Prove KYC, plus a webhook controller with signature verification.</Description>

--- a/Mono.Core/Services/Account/Abstractions/IAccountService.cs
+++ b/Mono.Core/Services/Account/Abstractions/IAccountService.cs
@@ -25,8 +25,18 @@ namespace Mono.Core.Accounts
         [Get("/accounts/{accountId}/statement")]
         Task<IApiResponse<MonoStandardResponse<StatementResponseModel>>> GetStatement(string accountId, [Query] StatementRequestModels statementRequestModels, CancellationToken cancellationToken = default);
         // accounts/{accountId}/transactions?start={start}&end={end}&narration={narration}&type={type}&paginate={paginate}&limit={limit}
+        //
+        // Mono returns this endpoint as a flat envelope:
+        //   { "status", "message", "timestamp", "data": [ {...transactions...} ] }
+        // — the `data` field is the transaction array directly, NOT wrapped in
+        // a nested object with its own `paging` + `data` fields. Refit needs
+        // the generic to match that shape (`List<Transaction>`) or
+        // System.Text.Json hits a type mismatch on `data: array → object` and
+        // hands us null Content. The public wrapper in AccountService
+        // converts back into TransactionResponseModel so existing consumers
+        // (e.g. `response.Data.Transactions`) keep working.
         [Get("/accounts/{accountId}/transactions")]
-        Task<IApiResponse<MonoStandardResponse<TransactionResponseModel>>> GetTransactions(string accountId, [Query] AccountTransactionsOptionsRequest accountTransactionsOptionsRequest, CancellationToken cancellationToken = default);
+        Task<IApiResponse<MonoStandardResponse<System.Collections.Generic.List<Transaction>>>> GetTransactions(string accountId, [Query] AccountTransactionsOptionsRequest accountTransactionsOptionsRequest, CancellationToken cancellationToken = default);
 
         // /accounts/{accountId}/balance — real-time balance (Feb 2025)
         [Get("/accounts/{accountId}/balance")]

--- a/Mono.Core/Services/Account/AccountService.cs
+++ b/Mono.Core/Services/Account/AccountService.cs
@@ -53,8 +53,31 @@ namespace Mono.Core.Accounts
 
         public async Task<MonoStandardResponse<TransactionResponseModel>> GetTransactions(string accountId, AccountTransactionsOptionsRequest accountTransactionsOptionsRequest, CancellationToken cancellationToken = default)
         {
-           var response = await _accountService.GetTransactions(accountId, accountTransactionsOptionsRequest, cancellationToken);
-             return response.HandleResponse();
+            // Refit deserializes into MonoStandardResponse<List<Transaction>>
+            // because that matches Mono's actual flat response shape. We
+            // adapt to TransactionResponseModel here so the public surface
+            // stays backward-compatible.
+            var response = await _accountService.GetTransactions(accountId, accountTransactionsOptionsRequest, cancellationToken);
+            var envelope = response.HandleResponse();
+            return new MonoStandardResponse<TransactionResponseModel>
+            {
+                Success = envelope.Success,
+                Status = envelope.Status,
+                Message = envelope.Message,
+                Timestamp = envelope.Timestamp,
+                MonoErrors = envelope.MonoErrors,
+                InAppErrors = envelope.InAppErrors,
+                Data = envelope.Data == null ? null : new TransactionResponseModel
+                {
+                    Transactions = envelope.Data,
+                    // Mono returns pagination info under "meta" on the top-level
+                    // envelope (both paginate=true and paginate=false). We
+                    // surface it on TransactionResponseModel.Paging so
+                    // consumers can read cursor + total via the same shape
+                    // they already expect.
+                    Paging = envelope.Meta
+                }
+            };
         }
 
         public async Task<MonoStandardResponse<AccountBalanceResponse>> GetAccountBalance(string accountId, CancellationToken cancellationToken = default)


### PR DESCRIPTION
## Summary

Mono returns \`/v2/accounts/{id}/transactions\` as a flat envelope with \`data\` as a top-level array and \`meta\` as the pagination object. The Refit signature was wrapped one level deeper than reality, so System.Text.Json hit a type mismatch and silently dropped the body. Verified against [the docs](https://docs.mono.co/api/bank-data/transactions) and a live sandbox capture.

## What Mono actually returns

\`\`\`json
{
  "status": "successful",
  "message": "Transaction retrieved successfully",
  "timestamp": "2024-04-12T06:18:17.117Z",
  "data": [ { "id": "...", "narration": "...", ... } ],
  "meta": { "total": 307, "page": 1, "previous": null, "next": "..." }
}
\`\`\`

## What the SDK previously expected

\`MonoStandardResponse<TransactionResponseModel>\` where \`TransactionResponseModel\` had its own \`paging\` + \`data\` fields — a double-wrapped shape Mono never sends.

## Fix

1. **\`IAccountService.GetTransactions\` Refit signature** → \`MonoStandardResponse<List<Transaction>>\`. Matches the wire.
2. **\`AccountService.GetTransactions\` public wrapper** → still returns \`MonoStandardResponse<TransactionResponseModel>\` for source-compat with existing consumers. Adapts the envelope, populating \`.Data.Transactions\` from the flat array and \`.Data.Paging\` from the top-level \`meta\`.
3. **\`MonoStandardResponse<T>\` gains \`Meta\` property** with \`[JsonPropertyName(\"meta\")]\`. Mono surfaces pagination consistently across list endpoints (transactions, payouts, mandates), so the envelope type captures it generically.
4. **\`TransactionResponseModel.Paging\`** is now populated correctly. Previously every consumer saw null because the wrapper was looking for a \`paging\` property Mono doesn't send.

## Verification

- [x] \`dotnet test -c Release\`: **139 passed, 0 failed, 23 skipped** (sandbox tests gated on \`MONO_SANDBOX_KEY\`, unchanged).
- [x] The test \`GetTransactions_ShouldReturnTransactionResponse\` now locks in the contract — constructs the flat envelope, sets realistic \`meta\` values, asserts they round-trip through the wrapper into \`response.Data.Paging\`.
- [x] Verified the response shape against:
  - Live capture: \`curl -H 'mono-sec-key: test_sk_...' https://api.withmono.com/v2/accounts/{id}/transactions?...\`
  - [docs.mono.co/api/bank-data/transactions](https://docs.mono.co/api/bank-data/transactions) reference example

## Backward compatibility

- ✅ Public wrapper signature unchanged
- ✅ \`response.Data.Transactions\` keeps working
- ✅ \`response.Data.Paging\` works now where it didn't before (previously null)
- ✅ \`MonoStandardResponse<T>.Meta\` is additive — old consumers don't notice

## Version

\`1.9.2 → 1.9.3\` (patch — fixes a runtime serialisation bug, additive to envelope).