### PR TITLE
fix(transactions): Transaction.Id maps to wire field 'id', not '_id'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,29 @@ All notable changes to **Mono.Core** are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project follows
 [Semantic Versioning](https://semver.org/).
 
+## [1.9.4] — 2026-05
+
+### Fixed
+
+- **`Transaction.Id` now maps to the wire field `id` instead of `_id`.**
+  Mono returns the transaction id as `id` (verified against
+  [docs.mono.co/api/bank-data/transactions](https://docs.mono.co/api/bank-data/transactions)
+  and a live sandbox capture). The previous attribute name `"_id"` was a
+  MongoDB-internal convention that never matched what Mono actually
+  serialises, so `Transaction.Id` was always null. Idempotent dedup
+  paths keyed on this field — including pace-api's transaction sync —
+  silently dropped every row. After 1.9.3 closed the response-shape
+  bug, this was the next layer of "transactions arrive but nothing
+  saves."
+
+### Added
+
+- **`Transaction.Currency`** and **`Transaction.Category`** fields.
+  Mono's actual responses include them; they were quietly dropped by
+  the SDK before. Currency is needed for multi-currency accounts;
+  Category is Mono's first-pass categorisation hint and is useful as
+  a fallback when local enrichment rules don't match.
+
 ## [1.9.3] — 2026-05
 
 ### Fixed

--- a/Mono.Core/Mono.Core.csproj
+++ b/Mono.Core/Mono.Core.csproj
@@ -5,7 +5,7 @@
 
 		<!-- ==================== NuGet package metadata ==================== -->
 		<PackageId>Mono.Core</PackageId>
-		<Version>1.9.3</Version>
+		<Version>1.9.4</Version>
 		<Authors>Adelowomi</Authors>
 		<Company>Harmonics Technology</Company>
 		<Description>A .NET client library for the Mono API (https://mono.co): Connect (Accounts, Customers), DirectPay, Disburse, Lookup (BVN, NIN, CAC, TIN, watchlist screening), Prove KYC, plus a webhook controller with signature verification.</Description>

--- a/Mono.Core/Services/Account/Models/TransactionResponseModel.cs
+++ b/Mono.Core/Services/Account/Models/TransactionResponseModel.cs
@@ -15,7 +15,13 @@ namespace Mono.Core.Accounts
 
     public class Transaction
     {
-        [JsonPropertyName("_id")]
+        // Mono returns the transaction id as `id` on the wire (verified against
+        // docs.mono.co/api/bank-data/transactions and a live sandbox capture).
+        // The previous attribute name "_id" came from MongoDB-internal
+        // convention and never matched what Mono actually serialises — so
+        // consumers always saw a null Id. Idempotent dedup paths that key on
+        // this field were silently no-oping.
+        [JsonPropertyName("id")]
         public string Id { get; set; }
 
         [JsonPropertyName("type")]
@@ -32,5 +38,19 @@ namespace Mono.Core.Accounts
 
         [JsonPropertyName("balance")]
         public long Balance { get; set; }
+
+        /// <summary>
+        /// Currency the transaction settled in (e.g. "NGN"). Optional on the
+        /// wire — Mono omits it for some legacy datasources.
+        /// </summary>
+        [JsonPropertyName("currency")]
+        public string Currency { get; set; }
+
+        /// <summary>
+        /// Mono's first-pass categorisation hint (e.g. "bank_charges",
+        /// "unknown"). Null when Mono hasn't categorised yet.
+        /// </summary>
+        [JsonPropertyName("category")]
+        public string Category { get; set; }
     }
 }


### PR DESCRIPTION
## Summary

Mono returns the transaction id as \`id\`. The SDK's \`Transaction\` model expected \`_id\` (MongoDB-internal convention), so \`Transaction.Id\` was always \`null\` after deserialisation. This patches the JsonPropertyName + adds two fields Mono actually sends that the SDK was dropping.

## Why this matters now

After 1.9.3 closed the response-shape mismatch (\`data: array\` not \`data: object\`), pace-api's sync still inserted zero rows even though Mono returned 267 transactions. The new \`MonoApiCalls\` audit table in pace-api captured the SDK-serialised response and showed every transaction field present **except** \`id\` — proving the JsonPropertyName mismatch meant \`Id\` was unread on the way in and unwritten on the way out.

\`pace-api/Pace.Infrastructure/Transactions/TransactionSyncService.cs\`:

\`\`\`csharp
foreach (var mt in monoTxns) {
    if (string.IsNullOrEmpty(mt.Id) || existingIds.Contains(mt.Id)) continue;
    // ... insert ...
}
\`\`\`

With \`mt.Id\` always null, every row was skipped silently.

## Verification

- Live sandbox capture confirms wire field is \`id\` (no underscore):
  \`\`\`json
  { "id": "6a18624ca50e19948876d10c", "narration": "...", ... }
  \`\`\`
- [docs.mono.co/api/bank-data/transactions](https://docs.mono.co/api/bank-data/transactions) reference example uses \`id\`
- \`dotnet test -c Release\`: **139 passed, 0 failed, 23 skipped**

## Additive fields

- **\`Transaction.Currency\`** — present in Mono's response, needed for multi-currency accounts
- **\`Transaction.Category\`** — Mono's first-pass categorisation hint (e.g. \`bank_charges\`, \`unknown\`)

Both are nullable strings. Consumers that don't read them notice nothing.

## Version

\`1.9.3 → 1.9.4\` (patch — fixes a runtime deserialisation bug, additive on \`Transaction\`).

## Summary by Sourcery

Fix transaction deserialization and extend the transaction model to align with Mono's actual API response.

New Features:
- Expose Transaction.Currency from Mono responses for multi-currency support.
- Expose Transaction.Category from Mono responses to surface Mono's categorisation hints.

Bug Fixes:
- Map Transaction.Id to the wire field "id" instead of the incorrect "_id" so deserialized transactions have a usable identifier and deduplication logic can function.

Documentation:
- Document the 1.9.4 changes in the changelog, including the corrected Transaction.Id mapping and the new Currency and Category fields.